### PR TITLE
DRAFT: RESTful task management experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,3 +3,1269 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hypha-rest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "futures-util",
+ "http-body-util",
+ "mime",
+ "rocksdb",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.1+9.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
+dependencies = [
+ "bindgen 0.69.5",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rocksdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
+name = "socket2"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "tokio"
+version = "1.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "bindgen 0.71.1",
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,11 @@
 [workspace]
-resolver = "2"
-members = []
-default-members = []
+resolver = "3"
+members = ["hypha-rest"]
+default-members = ["hypha-rest"]
 
 [workspace.package]
 publish = false
 edition = "2024"
-
-[workspace.dependencies]
-clap = { version = "4.5.31", features = ["derive"] }
-tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tokio = { version = "1.43.0", features = [
-    "macros",
-    "rt-multi-thread",
-    "sync",
-    "signal",
-] }
 
 [profile.profiling]
 inherits = "release"

--- a/hypha-rest/API.md
+++ b/hypha-rest/API.md
@@ -1,0 +1,62 @@
+# Hypha API
+
+```mermaid
+flowchart TD
+    subgraph Coordinator
+    A[Tasks API]
+    D[Scheduler] -->|Create Tasks definitions| A
+    S[(State)] <--> A
+    S <--> D
+    end
+
+    B[Worker 1] -->|Task Updates| A
+    A -->|Task Definitions| B
+    C[Worker 2] -->|Task Updates| A
+    A -->|Task Definitions| C
+
+```
+
+## Coordinator to worker communication API
+
+Data-parallel training and inference can be described by a list of tasks where some tasks depend on the results of other tasks.
+Therefore, coordinator-to-worker communication API communicates these tasks. What these tasks should be and what they depend on is determined by the coordinator. How they are executed is determined by the worker.
+Workers subscribe to the coordinator's stream of tasks. When scheduling a job, the coordinator decides which tasks to schedule based on the available resources and roles of workers and the dependencies between tasks and adds them to the stream.
+Workers receive tasks from the coordinator and execute them. Workers send task status updates to the coordinator.
+This is similar to the Kubernetes API and how it manages pods on kubelets. The different scheduling strategies (e.g., data-parallel inference, DiLoCo-based training) are handled by different implementations, similar to Kubernetes operators.
+
+The difference between Hypha's tasks and Kubernetes' pods is that tasks depend on the results of other tasks, while pods are independent units of work.
+I.e. these results (e.g., model weights, intermediate data) with can be inputs or outputs need to be referenced in the task definition and worker's need a mechanism to share them with each other.
+Furthermore, the different scheduling strategies impose different roles on the workers. For example, with DiLoCo, some workers are responsible for data aggregation and others for model training.
+The actual resource sharing mechanism is handled by different implementations. E.g., some resources can be shared via S3, while others can be shared via a shared file system, or through direct access via a peer-to-peer network.
+Peer-to-peer sharing could look like this: An API separate from the coordinator-worker communication API is needed to facilitate communication between workers. Though, since workers are already connected to the coordinator, the same communication channel could be used for both.
+If a worker isn't able to directly access a resource that's referenced in a task, it can request the resource from that API. Depending on their roles, workers are then either be instructed to push the resource to the requesting worker or to pull the resource from the resource-holding worker.
+
+## Example task definition
+
+```json
+{
+  "name": "task1",
+  "driver": {
+    "pytorch": {
+      "dataset": "dataset",
+      "model": "model",
+      ...
+    },
+  },
+  "resources": [
+    {
+      "name": "dataset",
+      "s3": {
+        "bucket": "my-bucket",
+        "key": "data.csv"
+      }
+    },
+    {
+      "name": "model",
+      "dht": {
+        "sha256": "abcdef1234567890"
+      }
+    }
+  ]
+}
+```

--- a/hypha-rest/Cargo.toml
+++ b/hypha-rest/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+edition.workspace = true
+publish.workspace = true
+name = "hypha-rest"
+version = "0.1.0"
+license = "Apache-2.0"
+
+[dependencies]
+anyhow = "1.0.97"
+axum = { version = "0.8.1", features = ["http2"] }
+futures-util = "0.3.31"
+rocksdb = { version = "0.23.0", default-features = false, features = [
+    "bindgen-runtime",
+    "zstd",
+] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+thiserror = "2.0.12"
+tokio = { version = "1.44.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = { version = "0.1.17", features = ["sync"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+uuid = { version = "1.16.0", features = ["serde", "v4"] }
+
+[dev-dependencies]
+bytes = "1.10.1"
+http-body-util = "0.1.3"
+mime = "0.3.17"
+tempfile = "3.19.1"
+tower = { version = "0.5.2", features = ["util"] }

--- a/hypha-rest/README.md
+++ b/hypha-rest/README.md
@@ -1,0 +1,34 @@
+# Hypha API Experiment
+
+Experiment on structuring the API around resources and working with them through a RESTful API. This is similar to how Kubernetes works.
+Workers would register by creating a `Worker` resource (not implemented here), then subscribe to a stream of tasks (implemented here).
+A scheduler, knowing which workers exist (through `Worker` resources), creates tasks for them. Workers run these tasks and send task updates.
+Different scheduling algorithm would be different resources as well, similar to operators in Kubernetes. With that, worker orchestration is done exclusively through `Task` resources, similar to pods in Kubernetes.
+
+Furthermore, persisting state with [RocksDB](https://rocksdb.org/) is tested as well. RocksDB provides an in-process key-value-store that persists all state to disk.
+
+## Example API Interactions
+
+```
+# Worker: Watch for task changes
+curl 'http://localhost:8080/api/v0/tasks?watch=true'
+
+# List tasks
+curl 'http://localhost:8080/api/v0/tasks'
+
+# Scheduler: Create a task
+curl --header "Content-Type: application/json" \
+     --request POST \
+     --data '{"driver": "foo"}' \
+     'http://localhost:8080/api/v0/tasks'
+
+# Worker: Update a task
+curl --header "Content-Type: application/json" \
+     --request PUT \
+     --data '{"id":"id","spec":{"driver":"foo"},"status":{"status":"running"}}' \
+     'http://localhost:8080/api/v0/tasks/{id}'
+
+# Delete a task
+curl --request DELETE \
+     'http://localhost:8080/api/v0/tasks/{id}'
+```

--- a/hypha-rest/src/api/mod.rs
+++ b/hypha-rest/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod v0;

--- a/hypha-rest/src/api/v0/mod.rs
+++ b/hypha-rest/src/api/v0/mod.rs
@@ -1,0 +1,3 @@
+mod task;
+
+pub use task::{Task, TaskSpec};

--- a/hypha-rest/src/api/v0/task/mod.rs
+++ b/hypha-rest/src/api/v0/task/mod.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskSpec {
+    pub driver: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskStatus {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub id: Uuid,
+    pub spec: TaskSpec,
+    pub status: TaskStatus,
+}
+
+impl Task {
+    pub fn new(spec: TaskSpec) -> Self {
+        let id = Uuid::new_v4();
+        Task {
+            id,
+            spec,
+            status: TaskStatus {
+                status: "pending".to_string(),
+            },
+        }
+    }
+
+    pub fn update(&mut self, task: &Task) {
+        // Task metadata is immutable, only spec and status can be updated
+        self.spec = task.spec.clone();
+        self.status = task.status.clone();
+    }
+}

--- a/hypha-rest/src/main.rs
+++ b/hypha-rest/src/main.rs
@@ -1,0 +1,37 @@
+use std::{error::Error, net::SocketAddr};
+
+use axum::serve::serve;
+use tokio::net::TcpListener;
+use tracing::{info, level_filters::LevelFilter};
+
+use crate::{
+    service::service,
+    state::{State, persistence::RocksDBPersistence},
+};
+
+mod api;
+mod service;
+mod state;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let state = State::new(RocksDBPersistence::try_new("state_db")?);
+
+    let listener = TcpListener::bind("[::1]:8080").await?;
+    info!(address = %listener.local_addr()?, "serving");
+    serve(
+        listener,
+        service(state).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
+
+    Ok(())
+}

--- a/hypha-rest/src/service/error.rs
+++ b/hypha-rest/src/service/error.rs
@@ -1,0 +1,40 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::state::error::StateError;
+
+/// Error type for the axum service.
+/// Provides an 'IntoResponse' implementation to be able to use 'Result'
+/// as responses in axum.
+/// See https://docs.rs/axum/latest/axum/error_handling/index.html
+#[derive(Debug)]
+pub enum ServiceError {
+    NotFound(String),
+    InternalServerError(String),
+}
+
+impl IntoResponse for ServiceError {
+    fn into_response(self) -> Response {
+        match self {
+            ServiceError::NotFound(resource) => {
+                (StatusCode::NOT_FOUND, format!("Not Found: {}", resource)).into_response()
+            }
+            ServiceError::InternalServerError(message) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Internal Server Error: {}", message),
+            )
+                .into_response(),
+        }
+    }
+}
+
+impl From<StateError> for ServiceError {
+    fn from(error: StateError) -> Self {
+        match error {
+            StateError::NotFound(uuid) => ServiceError::NotFound(uuid.to_string()),
+            StateError::Internal(message) => ServiceError::InternalServerError(message.to_string()),
+        }
+    }
+}

--- a/hypha-rest/src/service/mod.rs
+++ b/hypha-rest/src/service/mod.rs
@@ -1,0 +1,192 @@
+use std::convert::Infallible;
+
+use axum::{
+    Router,
+    body::Body,
+    extract::{Json, Path, Query, State as AppState},
+    response::{IntoResponse, Response, Sse, sse::Event},
+    routing::get,
+};
+use futures_util::{Stream, StreamExt};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::{
+    api::v0::{Task, TaskSpec},
+    service::error::ServiceError,
+    state::State,
+};
+
+mod error;
+
+type Result<T> = std::result::Result<T, ServiceError>;
+
+pub fn service(state: State) -> Router {
+    Router::new()
+        .route("/api/v0/tasks", get(handle_tasks).post(create_task))
+        .route(
+            "/api/v0/tasks/{id}",
+            get(get_task).put(update_task).delete(delete_task),
+        )
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    watch: Option<bool>,
+}
+
+async fn get_task(
+    Path(task_id): Path<Uuid>,
+    AppState(state): AppState<State>,
+) -> Result<Json<Task>> {
+    Ok(Json(state.read_task(&task_id).await?))
+}
+
+async fn update_task(
+    Path(task_id): Path<Uuid>,
+    AppState(state): AppState<State>,
+    Json(task): Json<Task>,
+) -> Result<Json<Task>> {
+    Ok(Json(state.update_task(&task_id, task).await?))
+}
+
+async fn delete_task(
+    Path(task_id): Path<Uuid>,
+    AppState(state): AppState<State>,
+) -> Result<Json<Task>> {
+    Ok(Json(state.delete_task(&task_id).await?))
+}
+
+async fn create_task(
+    AppState(state): AppState<State>,
+    Json(spec): Json<TaskSpec>,
+) -> Result<Json<Task>> {
+    Ok(Json(state.create_task(spec).await?))
+}
+
+async fn handle_tasks(
+    Query(params): Query<Params>,
+    AppState(state): AppState<State>,
+) -> Response<Body> {
+    if let Some(true) = params.watch {
+        watch_tasks(state).await.into_response()
+    } else {
+        list_tasks(state).await.into_response()
+    }
+}
+
+async fn list_tasks(state: State) -> Result<Json<Vec<Task>>> {
+    Ok(Json(state.list_tasks().await?))
+}
+
+async fn watch_tasks(
+    state: State,
+) -> Result<Sse<impl Stream<Item = std::result::Result<Event, Infallible>>>> {
+    let stream = state.watch_tasks().await?;
+    Ok(Sse::new(stream.map(|task| {
+        Ok(Event::default().json_data(task.unwrap()).unwrap())
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{self, Request, StatusCode},
+    };
+    use bytes::Bytes;
+    use http_body_util::BodyExt;
+    use tower::{Service, ServiceExt};
+
+    use crate::state::persistence::InMemoryPersistence;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_task_lifecycle() {
+        let state = State::new(InMemoryPersistence::new());
+        let mut app = service(state).into_service();
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v0/tasks")
+            .body(Body::empty())
+            .unwrap();
+        let response = ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"[]");
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v0/tasks")
+            .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+            .body(Body::from("{\"driver\": \"test\"}"))
+            .unwrap();
+        let response = ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let task: Task = serde_json::from_slice(&body).unwrap();
+        let task_id = task.id;
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v0/tasks")
+            .body(Body::empty())
+            .unwrap();
+        let response = ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let tasks_json = Bytes::from(serde_json::to_vec(&vec![task]).unwrap());
+        assert_eq!(&body[..], &tasks_json);
+
+        let request = Request::builder()
+            .method("DELETE")
+            .uri(format!("/api/v0/tasks/{}", task_id))
+            .body(Body::empty())
+            .unwrap();
+        let response = ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/api/v0/tasks")
+            .body(Body::empty())
+            .unwrap();
+        let response = ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"[]");
+    }
+}

--- a/hypha-rest/src/state/error.rs
+++ b/hypha-rest/src/state/error.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Error, Debug)]
+pub enum StateError {
+    #[error("task `{0}` not found")]
+    NotFound(Uuid),
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+}

--- a/hypha-rest/src/state/mod.rs
+++ b/hypha-rest/src/state/mod.rs
@@ -1,0 +1,200 @@
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio_stream::wrappers::BroadcastStream;
+use uuid::Uuid;
+
+use crate::{
+    api::v0::{Task, TaskSpec},
+    state::{error::StateError, persistence::StatePersistence},
+};
+
+pub mod error;
+pub mod persistence;
+
+type Result<T> = std::result::Result<T, StateError>;
+type Responder<T> = oneshot::Sender<Result<T>>;
+
+#[derive(Clone)]
+pub struct State {
+    sender: mpsc::Sender<Command>,
+}
+
+impl State {
+    pub fn new<S>(persistence: S) -> Self
+    where
+        S: StatePersistence + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::channel(32);
+        tokio::spawn(command_handler(receiver, persistence));
+        Self { sender }
+    }
+
+    pub async fn create_task(&self, spec: TaskSpec) -> Result<Task> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self.sender.send(Command::CreateTask { spec, sender }).await;
+        receiver.await.unwrap()
+    }
+
+    pub async fn read_task(&self, id: &Uuid) -> Result<Task> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self
+            .sender
+            .send(Command::ReadTask { id: *id, sender })
+            .await;
+        receiver.await.unwrap()
+    }
+
+    pub async fn update_task(&self, id: &Uuid, task: Task) -> Result<Task> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self
+            .sender
+            .send(Command::UpdateTask {
+                id: *id,
+                task,
+                sender,
+            })
+            .await;
+        receiver.await.unwrap()
+    }
+
+    pub async fn delete_task(&self, id: &Uuid) -> Result<Task> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self
+            .sender
+            .send(Command::DeleteTask { id: *id, sender })
+            .await;
+        receiver.await.unwrap()
+    }
+
+    pub async fn list_tasks(&self) -> Result<Vec<Task>> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self.sender.send(Command::ListTasks { sender }).await;
+        receiver.await.unwrap()
+    }
+
+    pub async fn watch_tasks(&self) -> Result<BroadcastStream<Task>> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self.sender.send(Command::WatchTasks { sender }).await;
+        receiver.await.unwrap()
+    }
+}
+
+#[derive(Debug)]
+enum Command {
+    CreateTask {
+        spec: TaskSpec,
+        sender: Responder<Task>,
+    },
+    ReadTask {
+        id: Uuid,
+        sender: Responder<Task>,
+    },
+    UpdateTask {
+        id: Uuid,
+        task: Task,
+        sender: Responder<Task>,
+    },
+    DeleteTask {
+        id: Uuid,
+        sender: Responder<Task>,
+    },
+    ListTasks {
+        sender: Responder<Vec<Task>>,
+    },
+    WatchTasks {
+        sender: Responder<BroadcastStream<Task>>,
+    },
+}
+
+async fn command_handler<S>(mut receiver: mpsc::Receiver<Command>, mut persistence: S)
+where
+    S: StatePersistence + Send,
+{
+    let (publisher, _) = broadcast::channel(16);
+
+    while let Some(command) = receiver.recv().await {
+        match command {
+            Command::CreateTask { spec, sender } => {
+                let task = Task::new(spec);
+
+                match persistence.put(&format!("task:{}", task.id), task.clone()) {
+                    Ok(_) => {
+                        let _ = sender.send(Ok(task.clone()));
+                        let _ = publisher.send(task);
+                    }
+                    Err(e) => {
+                        let _ = sender.send(Err(StateError::Internal(e)));
+                    }
+                }
+            }
+            Command::ReadTask { id, sender } => {
+                match persistence.get::<Task>(&format!("task:{}", id)) {
+                    Ok(task) => {
+                        if let Some(task) = task {
+                            let _ = sender.send(Ok(task.clone()));
+                        } else {
+                            let _ = sender.send(Err(StateError::NotFound(id)));
+                        }
+                    }
+                    Err(e) => {
+                        let _ = sender.send(Err(StateError::Internal(e)));
+                    }
+                }
+            }
+            Command::UpdateTask { id, task, sender } => {
+                match persistence.get::<Task>(&format!("task:{}", id)) {
+                    Ok(current_task) => {
+                        if let Some(current_task) = current_task {
+                            let mut current_task = current_task.clone();
+                            current_task.update(&task);
+
+                            match persistence.put(&format!("task:{}", id), current_task.clone()) {
+                                Ok(_) => {
+                                    let _ = sender.send(Ok(current_task.clone()));
+                                    let _ = publisher.send(current_task);
+                                }
+                                Err(e) => {
+                                    let _ = sender.send(Err(StateError::Internal(e)));
+                                }
+                            }
+                        } else {
+                            let _ = sender.send(Err(StateError::NotFound(id)));
+                        }
+                    }
+                    Err(e) => {
+                        let _ = sender.send(Err(StateError::Internal(e)));
+                    }
+                }
+            }
+            Command::DeleteTask { id, sender } => {
+                match persistence.delete::<Task>(&format!("task:{}", id)) {
+                    Ok(task) => {
+                        if let Some(task) = task {
+                            let _ = sender.send(Ok(task.clone()));
+                            let mut deleted_task = task;
+                            deleted_task.status.status = "deleted".to_string();
+                            let _ = publisher.send(deleted_task);
+                        } else {
+                            let _ = sender.send(Err(StateError::NotFound(id)));
+                        }
+                    }
+                    Err(e) => {
+                        let _ = sender.send(Err(StateError::Internal(e)));
+                    }
+                }
+            }
+            Command::ListTasks { sender } => match persistence.list("task:") {
+                Ok(tasks) => {
+                    let _ = sender.send(Ok(tasks));
+                }
+                Err(e) => {
+                    let _ = sender.send(Err(StateError::Internal(e)));
+                }
+            },
+            Command::WatchTasks { sender } => {
+                let subscriber = publisher.subscribe();
+                let stream = BroadcastStream::new(subscriber);
+                let _ = sender.send(Ok(stream));
+            }
+        }
+    }
+}

--- a/hypha-rest/src/state/persistence/in_memory.rs
+++ b/hypha-rest/src/state/persistence/in_memory.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::StatePersistence;
+
+/// InMemoryPersistence is a state persistence implementation using an in-memory HashMap.
+pub struct InMemoryPersistence {
+    data: HashMap<String, Value>,
+}
+
+impl InMemoryPersistence {
+    #[cfg(test)]
+    pub fn new() -> Self {
+        InMemoryPersistence {
+            data: HashMap::new(),
+        }
+    }
+}
+
+impl StatePersistence for InMemoryPersistence {
+    fn put<T>(&mut self, key: &str, value: T) -> Result<()>
+    where
+        T: Serialize,
+    {
+        self.data
+            .insert(key.to_string(), serde_json::to_value(value)?);
+        Ok(())
+    }
+
+    fn get<T>(&self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        Ok(serde_json::from_value(
+            self.data.get(key).ok_or(anyhow!("unknown key"))?.clone(),
+        )?)
+    }
+
+    fn delete<T>(&mut self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        if let Some(value) = self.data.remove(key) {
+            Ok(Some(serde_json::from_value(value)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn list<T>(&self, prefix: &str) -> Result<Vec<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        Ok(self
+            .data
+            .iter()
+            .filter(|(k, _)| k.starts_with(prefix))
+            .map(|(_, v)| serde_json::from_value(v.clone()))
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+}

--- a/hypha-rest/src/state/persistence/mod.rs
+++ b/hypha-rest/src/state/persistence/mod.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+
+#[cfg(test)]
+pub use in_memory::InMemoryPersistence;
+pub use rocksdb::RocksDBPersistence;
+use serde::{Deserialize, Serialize};
+
+mod in_memory;
+mod rocksdb;
+
+/// Persistence trait for storing and retrieving resources.
+/// We assume that implementations of this trait will be "fast",
+/// i.e. using blocking operations is not a concern here.
+/// TODO: Create an 'Error' struct instead of using 'anyhow::Error'.
+pub trait StatePersistence {
+    fn put<T>(&mut self, key: &str, value: T) -> Result<()>
+    where
+        T: Serialize;
+    fn get<T>(&self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>;
+    fn delete<T>(&mut self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>;
+    fn list<T>(&self, prefix: &str) -> Result<Vec<T>>
+    where
+        T: for<'de> Deserialize<'de>;
+}

--- a/hypha-rest/src/state/persistence/rocksdb.rs
+++ b/hypha-rest/src/state/persistence/rocksdb.rs
@@ -1,0 +1,110 @@
+use std::{path::Path, str};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::StatePersistence;
+
+/// RocksDBPersistence is a state persistence implementation using RocksDB.
+pub struct RocksDBPersistence {
+    db: rocksdb::DB,
+}
+
+impl RocksDBPersistence {
+    pub fn try_new<P>(path: P) -> Result<Self, rocksdb::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let db = rocksdb::DB::open_default(path)?;
+        Ok(Self { db })
+    }
+}
+
+impl StatePersistence for RocksDBPersistence {
+    fn put<T>(&mut self, key: &str, value: T) -> Result<()>
+    where
+        T: Serialize,
+    {
+        let task_bytes = serde_json::to_vec(&value)?;
+        self.db.put(key.as_bytes(), task_bytes)?;
+        Ok(())
+    }
+
+    fn get<T>(&self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let value = self.db.get_pinned(key.as_bytes())?;
+        match value {
+            Some(value) => {
+                let v: T = serde_json::from_slice(&value)?;
+                Ok(Some(v))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn delete<T>(&mut self, key: &str) -> Result<Option<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let value = self.db.get_pinned(key.as_bytes())?;
+        match value {
+            Some(value) => {
+                self.db.delete(key.as_bytes())?;
+                let v: T = serde_json::from_slice(&value)?;
+                Ok(Some(v))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn list<T>(&self, prefix: &str) -> Result<Vec<T>>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let mut values = Vec::new();
+        for iter in self.db.prefix_iterator(prefix.as_bytes()) {
+            let (_, value) = iter?;
+            let v: T = serde_json::from_slice(&value)?;
+            values.push(v);
+        }
+        Ok(values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn test_rocksdb_persistence() {
+        let path = tempdir().unwrap();
+        let mut persistence = RocksDBPersistence::try_new(path).unwrap();
+
+        let key = "test_key";
+        let value = "test_value".to_string();
+
+        persistence.put(key, value.clone()).unwrap();
+        let retrieved_value: String = persistence.get(key).unwrap().unwrap();
+        assert_eq!(retrieved_value, value);
+
+        let _ = persistence.delete::<String>(key).unwrap();
+        let deleted_value: Option<String> = persistence.get(key).unwrap();
+        assert!(deleted_value.is_none());
+
+        let prefix = "test";
+        persistence
+            .put("test_key1", "test_value1".to_string())
+            .unwrap();
+        persistence
+            .put("test_key2", "test_value2".to_string())
+            .unwrap();
+        let list: Vec<String> = persistence.list(prefix).unwrap();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0], "test_value1");
+        assert_eq!(list[1], "test_value2");
+    }
+}


### PR DESCRIPTION
Provides a REST API for tasks. Workers and schedulers interact with these tasks, therefore providing a state of the current work.

Experiment on structuring the API around resources and working with them through a RESTful API. This is similar to how Kubernetes works.
Workers would register by creating a `Worker` resource (not implemented here), then subscribe to a stream of tasks (implemented here).
A scheduler, knowing which workers exist (through `Worker` resources), creates tasks for them. Workers run these tasks and send task updates.
Different scheduling algorithm would be different resources as well, similar to operators in Kubernetes. With that, worker orchestration is done exclusively through `Task` resources, similar to pods in Kubernetes.

Furthermore, persisting state with [RocksDB](https://rocksdb.org/) is tested as well. RocksDB provides an in-process key-value-store that persists all state to disk.