### PR TITLE
feat: gossipsub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -376,9 +376,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -933,9 +933,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1026,7 +1026,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.0",
+ "rand 0.9.1",
  "socket2",
  "thiserror 2.0.12",
  "tinyvec",
@@ -1048,7 +1048,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.0",
+ "rand 0.9.1",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.12",
@@ -1492,9 +1492,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libp2p"
@@ -1506,7 +1506,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
@@ -1634,7 +1634,7 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "hashlink",
  "hex_fmt",
  "libp2p-core",
@@ -1674,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
+checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -1686,7 +1686,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
@@ -2452,7 +2452,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -2483,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2584,13 +2584,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2644,13 +2644,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2679,7 +2678,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2783,7 +2782,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3002,9 +3001,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -3079,9 +3078,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3288,13 +3287,14 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3987,11 +3987,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -4007,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1.43.0", features = [
     "sync",
     "signal",
 ] }
-tokio-stream = "0.1.17"
+tokio-stream = { version = "0.1.17", features = ["sync"] }
 mockall = "0.13.1"
 proptest = "1.6.0"
 

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -3,12 +3,7 @@ mod network;
 use std::error::Error;
 
 use clap::Parser;
-use futures_util::{AsyncReadExt, StreamExt};
-use hypha_network::{
-    kad::KademliaInterface, listen::ListenInterface, stream::StreamReceiverInterface,
-    swarm::SwarmDriver, utils::generate_ed25519,
-};
-use tokio::{sync::oneshot, task::LocalSet};
+use hypha_network::{listen::ListenInterface, swarm::SwarmDriver, utils::generate_ed25519};
 use tracing_subscriber::EnvFilter;
 
 use crate::network::Network;
@@ -22,9 +17,9 @@ struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let _ = tracing_subscriber::fmt()
+    tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
+        .init();
 
     let opt = Opt::parse();
 
@@ -33,94 +28,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
         opt.secret_key_seed
     );
 
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
-
-    let opt = Opt::parse();
-
     let local_key = generate_ed25519(opt.secret_key_seed).expect("only errors on wrong length");
 
     let (network, network_driver) = Network::create(local_key)?;
+    let task = tokio::spawn(network_driver.run());
 
-    // Create a LocalSet
-    let local = LocalSet::new();
+    network
+        .listen("/ip4/0.0.0.0/udp/8888/quic-v1".parse()?)
+        .await?;
+    network.listen("/ip4/0.0.0.0/tcp/8888".parse()?).await?;
+    tracing::info!("Successfully listening");
 
-    // Spawn the NetworkDriver inside the LocalSet
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-    local.spawn_local(async move {
-        match tokio::select! {
-            result = network_driver.run() => result,
-            _ = shutdown_rx => {
-                tracing::info!("Network shutdown requested");
-                Ok(())
-            }
-        } {
-            Ok(()) => tracing::info!("Network driver shut down gracefully"),
-            Err(e) => tracing::error!("Network runner error: {:?}", e),
-        }
-    });
-
-    let main_task: tokio::task::JoinHandle<Result<(), Box<dyn Error + Send + Sync>>> =
-        tokio::spawn(async move {
-            let _ = network
-                .listen("/ip4/0.0.0.0/udp/0000/quic-v1".parse()?)
-                .await;
-            let _ = network.listen("/ip4/0.0.0.0/tcp/0000".parse()?).await;
-            tracing::info!("Successfully listening");
-
-            let _ = network.provide("test").await;
-
-            let mut streams = network.streams()?;
-
-            while let Some((peer, mut stream)) = streams.next().await {
-                tokio::spawn(async move {
-                    let mut buf = [0u8; 100];
-                    let mut total = 0;
-                    loop {
-                        let read = stream.read(&mut buf).await.unwrap();
-                        if read == 0 {
-                            break;
-                        }
-
-                        total += read;
-
-                        // We can also write responses back.
-                        // stream.write_all(&buf[..read]).await?;
-                    }
-
-                    tracing::info!(bytes=total, peer=%peer, "Received");
-                });
-            }
-
-            // Wait for Ctrl+C signal
-            tokio::signal::ctrl_c().await?;
-
-            // Signal shutdown
-            tracing::info!("Shutting down...");
-            let _ = shutdown_tx.send(());
-
-            Ok(())
-        });
-
-    tokio::select! {
-        _ = local => {
-            tracing::info!("LocalSet completed");
-        },
-        result = main_task => {
-            match result {
-                Ok(inner_result) => {
-                    if let Err(e) = inner_result {
-                        tracing::error!("Main task error: {:?}", e);
-                    }
-                },
-                Err(e) => {
-                    tracing::error!("Main task panicked: {:?}", e);
-                }
-            }
-        }
-    }
-
-    tracing::info!("Shutdown complete");
+    let _ = task.await?;
     Ok(())
 }

--- a/crates/network/src/gossipsub.rs
+++ b/crates/network/src/gossipsub.rs
@@ -1,0 +1,244 @@
+use std::{collections::HashMap, error::Error, fmt::Display};
+
+use libp2p::{gossipsub, swarm::NetworkBehaviour};
+use tokio::sync::{broadcast, oneshot};
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::swarm::SwarmDriver;
+
+pub type Subscriptions = HashMap<gossipsub::TopicHash, broadcast::Sender<Vec<u8>>>;
+
+pub trait GossipsubBehaviour {
+    fn gossipsub(&mut self) -> &mut gossipsub::Behaviour;
+}
+
+pub enum GossipsubAction {
+    Publish(
+        gossipsub::IdentTopic,
+        Vec<u8>,
+        oneshot::Sender<Result<(), GossipsubError>>,
+    ),
+    Subscribe(
+        gossipsub::IdentTopic,
+        oneshot::Sender<Result<broadcast::Receiver<Vec<u8>>, GossipsubError>>,
+    ),
+    Unsubscribe(
+        gossipsub::IdentTopic,
+        oneshot::Sender<Result<(), GossipsubError>>,
+    ),
+}
+
+#[derive(Debug)]
+pub enum GossipsubError {
+    Subscription(gossipsub::SubscriptionError),
+    Publish(gossipsub::PublishError),
+}
+
+impl Error for GossipsubError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+impl Display for GossipsubError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Gossipsub error")
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait GossipsubDriver<TBehavior>: SwarmDriver<TBehavior>
+where
+    TBehavior: NetworkBehaviour + GossipsubBehaviour,
+{
+    fn subscriptions(&mut self) -> &mut Subscriptions;
+
+    async fn process_gossipsub_action(&mut self, action: GossipsubAction) {
+        match action {
+            GossipsubAction::Publish(topic, data, tx) => {
+                if let Err(e) = self
+                    .swarm()
+                    .behaviour_mut()
+                    .gossipsub()
+                    .publish(topic, data)
+                {
+                    let _ = tx.send(Err(GossipsubError::Publish(e)));
+                } else {
+                    let _ = tx.send(Ok(()));
+                }
+            }
+            GossipsubAction::Subscribe(topic, tx) => {
+                match self.swarm().behaviour_mut().gossipsub().subscribe(&topic) {
+                    Ok(true) => {
+                        let (pubsub_tx, pubsub_rx) = broadcast::channel(5);
+                        self.subscriptions().insert(topic.hash(), pubsub_tx);
+                        let _ = tx.send(Ok(pubsub_rx));
+                    }
+                    Ok(false) => {
+                        // We already subscribed to this topic and create a new receiver from the existing sender.
+                        // We expect the sender to be present in the map, therefore we unwrap.
+                        let pubsub_rx = self
+                            .subscriptions()
+                            .get(&topic.hash())
+                            .map(|sub_tx| sub_tx.subscribe())
+                            .unwrap();
+                        let _ = tx.send(Ok(pubsub_rx));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(GossipsubError::Subscription(e)));
+                    }
+                };
+            }
+            GossipsubAction::Unsubscribe(topic, tx) => {
+                if self.swarm().behaviour_mut().gossipsub().unsubscribe(&topic) {
+                    self.subscriptions().remove(&topic.hash());
+                }
+                let _ = tx.send(Ok(()));
+            }
+        }
+    }
+
+    async fn process_gossipsub_event(&mut self, event: gossipsub::Event) {
+        match event {
+            gossipsub::Event::Message { message, .. } => {
+                let topic = message.topic;
+                if let Some(sub_tx) = self.subscriptions().get(&topic) {
+                    let _ = sub_tx.send(message.data);
+                } else {
+                    tracing::debug!("No subscription for topic: {:?}", topic);
+                }
+            }
+            _ => {
+                tracing::debug!("Unhandled gossipsub event: {:?}", event);
+            }
+        }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait GossipsubInterface {
+    async fn send(&self, action: GossipsubAction);
+
+    async fn subscribe(&self, topic: &str) -> Result<BroadcastStream<Vec<u8>>, GossipsubError> where
+    {
+        let (tx, rx) = oneshot::channel();
+        self.send(GossipsubAction::Subscribe(
+            gossipsub::IdentTopic::new(topic),
+            tx,
+        ))
+        .await;
+
+        match rx.await.unwrap() {
+            Ok(sub_rx) => Ok(BroadcastStream::new(sub_rx)),
+            Err(_) => todo!(),
+        }
+    }
+
+    async fn unsubscribe(&self, topic: &str) -> Result<(), GossipsubError> {
+        let (tx, rx) = oneshot::channel();
+        self.send(GossipsubAction::Unsubscribe(
+            gossipsub::IdentTopic::new(topic),
+            tx,
+        ))
+        .await;
+        rx.await.unwrap()
+    }
+
+    async fn publish<T>(&self, topic: &str, data: T) -> Result<(), GossipsubError>
+    where
+        T: Into<Vec<u8>>,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.send(GossipsubAction::Publish(
+            gossipsub::IdentTopic::new(topic),
+            data.into(),
+            tx,
+        ))
+        .await;
+        rx.await.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::mock;
+    use tokio_stream::StreamExt;
+
+    use super::*;
+
+    mock! {
+        TestInterface {}
+
+        impl GossipsubInterface for TestInterface {
+            async fn send(&self, action: GossipsubAction);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_gossipsub_interface_subscribe() {
+        let (sub_tx, _) = broadcast::channel(1);
+        let mock_sub_tx = sub_tx.clone();
+        let mut mock = MockTestInterface::new();
+
+        mock.expect_send()
+            .withf(|action| matches!(action, GossipsubAction::Subscribe(_, _)))
+            .times(1)
+            .returning(move |action| match action {
+                GossipsubAction::Subscribe(_, tx) => {
+                    let sub_rx = mock_sub_tx.subscribe();
+                    let _ = tx.send(Ok(sub_rx));
+                }
+                _ => {}
+            });
+
+        let result = mock.subscribe("test_topic").await;
+        assert!(result.is_ok());
+        let mut result = result.unwrap();
+
+        sub_tx.send(vec![1, 2, 3]).unwrap();
+
+        let received = result.next().await.unwrap();
+        assert_eq!(received, Ok(vec![1, 2, 3]));
+    }
+
+    #[tokio::test]
+    async fn test_gossipsub_interface_unsubscribe() {
+        let mut mock = MockTestInterface::new();
+
+        mock.expect_send()
+            .withf(|action| matches!(action, GossipsubAction::Unsubscribe(_, _)))
+            .times(1)
+            .returning(move |action| match action {
+                GossipsubAction::Unsubscribe(_, tx) => {
+                    let _ = tx.send(Ok(()));
+                }
+                _ => {}
+            });
+
+        let result = mock.unsubscribe("test_topic").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_gossipsub_interface_publish() {
+        let (sub_tx, mut sub_rx) = broadcast::channel(1);
+        let mut mock = MockTestInterface::new();
+
+        mock.expect_send()
+            .withf(|action| matches!(action, GossipsubAction::Publish(_, _, _)))
+            .times(1)
+            .returning(move |action| match action {
+                GossipsubAction::Publish(_, data, tx) => {
+                    let _ = sub_tx.send(data);
+                    let _ = tx.send(Ok(()));
+                }
+                _ => {}
+            });
+
+        let result = mock.publish("test_topic", vec![1, 2, 3]).await;
+        assert!(result.is_ok());
+
+        let received = sub_rx.recv().await.unwrap();
+        assert_eq!(received, vec![1, 2, 3]);
+    }
+}

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod dial;
 pub mod error;
+pub mod gossipsub;
 pub mod kad;
 pub mod listen;
 pub mod stream;

--- a/crates/scheduler/src/main.rs
+++ b/crates/scheduler/src/main.rs
@@ -1,13 +1,13 @@
 mod network;
 
-use std::{error::Error, sync::Arc};
+use std::{error::Error, time::Duration};
 
 use clap::Parser;
 use hypha_network::{
-    dial::DialInterface, kad::KademliaInterface, swarm::SwarmDriver, utils::generate_ed25519,
+    dial::DialInterface, gossipsub::GossipsubInterface, kad::KademliaInterface,
+    listen::ListenInterface, swarm::SwarmDriver, utils::generate_ed25519,
 };
 use libp2p::Multiaddr;
-use tokio::{sync::oneshot, task::LocalSet};
 use tracing_subscriber::EnvFilter;
 
 use crate::network::Network;
@@ -23,9 +23,9 @@ struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let _ = tracing_subscriber::fmt()
+    tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
+        .init();
 
     let opt = Opt::parse();
 
@@ -34,115 +34,32 @@ async fn main() -> Result<(), Box<dyn Error>> {
         opt.secret_key_seed
     );
 
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
-
-    let opt = Opt::parse();
-
     let local_key = generate_ed25519(opt.secret_key_seed).expect("only errors on wrong length");
+    let gateway_address = opt.gateway_address.parse::<Multiaddr>()?;
 
-    let (network_interface, network_driver) = Network::create(local_key)?;
-    let network = Arc::new(network_interface);
+    let (network, network_driver) = Network::create(local_key)?;
+    tokio::spawn(network_driver.run());
 
-    // Create a LocalSet
-    let local = LocalSet::new();
+    network
+        .listen("/ip4/0.0.0.0/udp/0/quic-v1".parse()?)
+        .await?;
+    network.listen("/ip4/0.0.0.0/tcp/0".parse()?).await?;
+    tracing::info!("Successfully listening");
 
-    // Spawn the NetworkDriver inside the LocalSet
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-    local.spawn_local(async move {
-        match tokio::select! {
-            result = network_driver.run() => result,
-            _ = shutdown_rx => {
-                tracing::info!("Network shutdown requested");
-                Ok(())
-            }
-        } {
-            Ok(()) => tracing::info!("Network driver shut down gracefully"),
-            Err(e) => tracing::error!("Network driver error: {:?}", e),
-        }
-    });
+    // Dial the gateway address
+    let _gateway_peer_id = network.dial(gateway_address).await?;
 
-    let main_task = tokio::spawn(async move {
-        // Dial the gatewaty address
-        let _peer_id = match network
-            .dial(opt.gateway_address.parse::<Multiaddr>()?)
-            .await
-        {
-            Ok(peer_id) => peer_id,
-            Err(e) => {
-                tracing::error!("Failed to dial hub: {:?}", e);
-                return Err(Box::new(e) as Box<dyn Error + Send + Sync>);
-            }
-        };
+    // Wait a bit until DHT bootstrapping is done.
+    // Once we receive an 'Identify' message, bootstrapping will start.
+    // TODO: Provide a way to wait for this event
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
-        let provider = network.find_provider("cpu").await;
-        tracing::info!(provider=?provider,"Found CPU provider");
+    let record = network.get("cpu").await?;
+    tracing::info!(record=?record,"Found CPU record");
 
-        // let provider = network.find_provider("test").await;
-        // tracing::info!(provider=?provider,"Found Test provider");
-
-        let record = network.get("cpu").await;
-        tracing::info!(record=?record,"Found CPU record");
-
-        // Stream data to gateway
-        // let start_time = Instant::now();
-        // let mut streams: Vec<JoinHandle<Result<(), Box<dyn Error + Send + Sync>>>> = Vec::new();
-        // for i in 0..TASKS {
-        //     let network_clone = Arc::clone(&network);
-        //     streams.push(task::spawn(async move {
-        //         tracing::info!(i=%i, "Starting stream");
-
-        //         let mut stream = network_clone.stream(peer_id).await?;
-
-        //         let bytes = vec![0u8; GIGABYTE / TASKS];
-
-        //         stream.write_all(&bytes).await?;
-        //         stream.close().await.ok();
-
-        //         Ok(())
-        //     }))
-        // }
-
-        // let _ = join_all(streams).await;
-
-        // // Record the elapsed time after the transfer
-        // let duration = start_time.elapsed();
-        // tracing::info!("Transferred {:?} in {:?}", GIGABYTE, duration);
-
-        // // Optionally, compute throughput (e.g., in MB/s)
-        // let seconds = duration.as_secs_f64();
-        // let throughput = (GIGABYTE as f64) / seconds / (1024.0 * 1024.0);
-        // tracing::info!("Throughput: {:.2} MB/s", throughput);
-
-        // Wait for Ctrl+C signal
-        tokio::signal::ctrl_c().await?;
-
-        // Signal shutdown
-        tracing::info!("Shutting down...");
-        let _ = shutdown_tx.send(());
-
-        Ok(())
-    });
-
-    tokio::select! {
-        _ = local => {
-            tracing::info!("LocalSet completed");
-        },
-        result = main_task => {
-            match result {
-                Ok(inner_result) => {
-                    if let Err(e) = inner_result {
-                        tracing::error!("Main task error: {:?}", e);
-                    }
-                },
-                Err(e) => {
-                    tracing::error!("Main task panicked: {:?}", e);
-                }
-            }
-        }
+    loop {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        tracing::info!("Publishing message");
+        let _ = network.publish("messages", "test").await;
     }
-
-    tracing::info!("Shutdown complete");
-    Ok(())
 }

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -1,24 +1,28 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use futures_util::stream::StreamExt;
 use hypha_network::{
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
     error::HyphaError,
+    gossipsub::{
+        GossipsubAction, GossipsubBehaviour, GossipsubDriver, GossipsubInterface, Subscriptions,
+    },
     kad::{
         KademliaAction, KademliaBehavior, KademliaDriver, KademliaInterface, KademliaResult,
         PendingQueries,
     },
+    listen::{ListenAction, ListenDriver, ListenInterface, PendingListens},
     stream::{StreamInterface, StreamSenderInterface},
     swarm::SwarmDriver,
 };
 use libp2p::PeerId;
 use libp2p::{
-    Swarm, SwarmBuilder, identify, identity, kad, ping,
+    Swarm, SwarmBuilder, gossipsub, identify, identity, kad, ping,
     swarm::{ConnectionId, DialError, NetworkBehaviour, SwarmEvent},
     tcp, tls, yamux,
 };
 use libp2p_stream as stream;
-use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 
 #[derive(Clone)]
 pub(crate) struct Network {
@@ -32,27 +36,30 @@ pub(crate) struct Behaviour {
     identify: identify::Behaviour,
     stream: stream::Behaviour,
     kademlia: kad::Behaviour<kad::store::MemoryStore>,
+    gossipsub: gossipsub::Behaviour,
 }
 
 pub(crate) struct NetworkDriver {
     swarm: Swarm<Behaviour>,
     pending_dials_map: PendingDials,
+    pending_listen_map: PendingListens,
     pending_queries_map: PendingQueries,
+    subscriptions: Subscriptions,
     action_receiver: mpsc::Receiver<Action>,
 }
 
 enum Action {
     Dial(DialAction),
+    Listen(ListenAction),
     Kademlia(KademliaAction),
+    Gossipsub(GossipsubAction),
 }
 
 impl Network {
     pub fn create(identity: identity::Keypair) -> Result<(Self, NetworkDriver), HyphaError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
-        let mut kademlia_config = kad::Config::default();
-        kademlia_config.disjoint_query_paths(true);
 
-        let mut swarm = SwarmBuilder::with_existing_identity(identity)
+        let swarm = SwarmBuilder::with_existing_identity(identity)
             .with_tokio()
             .with_tcp(
                 tcp::Config::default(),
@@ -68,19 +75,18 @@ impl Network {
                     key.public(),
                 )),
                 stream: stream::Behaviour::new(),
-                kademlia: kad::Behaviour::with_config(
+                kademlia: kad::Behaviour::new(
                     key.public().to_peer_id(),
                     kad::store::MemoryStore::new(key.public().to_peer_id()),
-                    kademlia_config,
                 ),
+                gossipsub: gossipsub::Behaviour::new(
+                    gossipsub::MessageAuthenticity::Signed(key.clone()),
+                    gossipsub::Config::default(),
+                )
+                .unwrap(),
             })
             .map_err(|_| HyphaError::SwarmError("Failed to create swarm behavior.".to_string()))?
             .build();
-
-        swarm
-            .behaviour_mut()
-            .kademlia
-            .set_mode(Some(kad::Mode::Client));
 
         Ok((
             Network {
@@ -89,8 +95,10 @@ impl Network {
             },
             NetworkDriver {
                 swarm,
-                pending_dials_map: Arc::new(Mutex::new(HashMap::default())),
-                pending_queries_map: Arc::new(Mutex::new(HashMap::default())),
+                pending_dials_map: HashMap::default(),
+                pending_listen_map: HashMap::default(),
+                pending_queries_map: HashMap::default(),
+                subscriptions: HashMap::default(),
                 action_receiver,
             },
         ))
@@ -103,18 +111,32 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
             tokio::select! {
                 event = self.swarm.select_next_some() => {
                     match event {
-                        SwarmEvent::ConnectionEstablished { connection_id, peer_id, endpoint, .. } => {
-                            // TODO: Move into the kademlia module also I wonder whether we really should add all and instead may just want to add the gateway.
-                            self.swarm.behaviour_mut().kademlia.add_address(&peer_id, endpoint.get_remote_address().clone());
-
+                        SwarmEvent::ConnectionEstablished { connection_id, peer_id, .. } => {
                             self.process_connection_established(peer_id, &connection_id,).await;
                         }
                         SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
                             self.process_connection_error(&connection_id, error).await;
                         }
+                        SwarmEvent::NewListenAddr { listener_id, address } => {
+                            tracing::info!(address=%address, "New listen address");
+                            self.process_new_listen_addr(&listener_id).await;
+                        }
+                        SwarmEvent::ExternalAddrConfirmed { address, .. } => {
+                            tracing::info!("External address confirmed: {:?}", address);
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Received { peer_id, info, .. })) => {
+                            // Add known addresses of peers to the Kademlia routing table
+                            tracing::debug!(peer_id=%peer_id, info=?info, "Adding address to Kademlia routing table");
+                            for addr in info.listen_addrs {
+                                self.swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
+                            }
+                        }
                         SwarmEvent::Behaviour(BehaviourEvent::Kademlia(kad::Event::OutboundQueryProgressed {id,  result, step, ..})) => {
                              self.process_kademlia_query_result(id, result, step).await;
-                         }
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(event)) => {
+                        self.process_gossipsub_event(event).await;
+                        }
                         _ => {
                             tracing::debug!("Unhandled event: {:?}", event);
                         }
@@ -125,13 +147,22 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         Action::Dial(action) => {
                             self.process_dial_action(action).await;
                         }
+                        Action::Listen(action) => {
+                            self.process_listen_action(action).await;
+                        }
                         Action::Kademlia(action) => {
                             self.process_kademlia_action(action).await;
                         }
+                        Action::Gossipsub(action) => {
+                            self.process_gossipsub_action(action).await;
+                        }
                     }
                 },
+                else => break
             }
         }
+
+        Ok(())
     }
 
     fn swarm(&mut self) -> &mut Swarm<Behaviour> {
@@ -147,9 +178,24 @@ impl DialInterface for Network {
 
 impl DialDriver<Behaviour> for NetworkDriver {
     fn pending_dials(
-        &self,
-    ) -> Arc<Mutex<HashMap<ConnectionId, oneshot::Sender<Result<PeerId, DialError>>>>> {
-        self.pending_dials_map.clone()
+        &mut self,
+    ) -> &mut HashMap<ConnectionId, oneshot::Sender<Result<PeerId, DialError>>> {
+        &mut self.pending_dials_map
+    }
+}
+
+impl ListenInterface for Network {
+    async fn send(&self, action: ListenAction) {
+        self.action_sender
+            .send(Action::Listen(action))
+            .await
+            .unwrap();
+    }
+}
+
+impl ListenDriver<Behaviour> for NetworkDriver {
+    fn pending_listens(&mut self) -> &mut PendingListens {
+        &mut self.pending_listen_map
     }
 }
 
@@ -169,15 +215,36 @@ impl KademliaBehavior for Behaviour {
 
 impl KademliaDriver<Behaviour> for NetworkDriver {
     fn pending_queries(
-        &self,
-    ) -> Arc<Mutex<HashMap<libp2p::kad::QueryId, mpsc::Sender<KademliaResult>>>> {
-        self.pending_queries_map.clone()
+        &mut self,
+    ) -> &mut HashMap<libp2p::kad::QueryId, mpsc::Sender<KademliaResult>> {
+        &mut self.pending_queries_map
     }
 }
 impl KademliaInterface for Network {
     async fn send(&self, action: KademliaAction) {
         self.action_sender
             .send(Action::Kademlia(action))
+            .await
+            .unwrap();
+    }
+}
+
+impl GossipsubBehaviour for Behaviour {
+    fn gossipsub(&mut self) -> &mut gossipsub::Behaviour {
+        &mut self.gossipsub
+    }
+}
+
+impl GossipsubDriver<Behaviour> for NetworkDriver {
+    fn subscriptions(&mut self) -> &mut Subscriptions {
+        &mut self.subscriptions
+    }
+}
+
+impl GossipsubInterface for Network {
+    async fn send(&self, action: GossipsubAction) {
+        self.action_sender
+            .send(Action::Gossipsub(action))
             .await
             .unwrap();
     }

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -1,13 +1,14 @@
 mod network;
 
-use std::{error::Error, sync::Arc};
+use std::{error::Error, time::Duration};
 
 use clap::Parser;
+use futures_util::StreamExt;
 use hypha_network::{
-    dial::DialInterface, kad::KademliaInterface, swarm::SwarmDriver, utils::generate_ed25519,
+    dial::DialInterface, gossipsub::GossipsubInterface, kad::KademliaInterface,
+    listen::ListenInterface, swarm::SwarmDriver, utils::generate_ed25519,
 };
 use libp2p::Multiaddr;
-use tokio::{sync::oneshot, task::LocalSet};
 use tracing_subscriber::EnvFilter;
 
 use crate::network::Network;
@@ -23,9 +24,9 @@ struct Opt {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let _ = tracing_subscriber::fmt()
+    tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
+        .init();
 
     let opt = Opt::parse();
 
@@ -34,119 +35,41 @@ async fn main() -> Result<(), Box<dyn Error>> {
         opt.secret_key_seed
     );
 
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .try_init();
-
-    let opt = Opt::parse();
-
     let local_key = generate_ed25519(opt.secret_key_seed).expect("only errors on wrong length");
+    let gateway_address = opt.gateway_address.parse::<Multiaddr>()?;
 
-    let (network_interface, network_driver) = Network::create(local_key)?;
-    let network = Arc::new(network_interface);
+    let (network, network_driver) = Network::create(local_key)?;
+    tokio::spawn(network_driver.run());
 
-    // Create a LocalSet
-    let local = LocalSet::new();
+    network
+        .listen("/ip4/0.0.0.0/udp/0/quic-v1".parse()?)
+        .await?;
+    network.listen("/ip4/0.0.0.0/tcp/0".parse()?).await?;
+    tracing::info!("Successfully listening");
 
-    // Spawn the NetworkDriver inside the LocalSet
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-    local.spawn_local(async move {
-        match tokio::select! {
-            result = network_driver.run() => result,
-            _ = shutdown_rx => {
-                tracing::info!("Network shutdown requested");
-                Ok(())
-            }
-        } {
-            Ok(()) => tracing::info!("Network driver shut down gracefully"),
-            Err(e) => tracing::error!("Network driver error: {:?}", e),
-        }
-    });
+    // Dial the gatewaty address
+    let _gateway_peer_id = network.dial(gateway_address).await?;
 
-    let main_task = tokio::spawn(async move {
-        // Dial the gatewaty address
-        let _peer_id = match network
-            .dial(opt.gateway_address.parse::<Multiaddr>()?)
-            .await
-        {
-            Ok(peer_id) => peer_id,
-            Err(e) => {
-                tracing::error!("Failed to dial hub: {:?}", e);
-                return Err(Box::new(e) as Box<dyn Error + Send + Sync>);
-            }
-        };
+    // Wait a bit until DHT bootstrapping is done.
+    // Once we receive an 'Identify' message, bootstrapping will start.
+    // TODO: Provide a way to wait for this event
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
-        network
-            .store(libp2p::kad::Record {
-                key: libp2p::kad::RecordKey::new(&"cpu"),
-                value: "test".as_bytes().to_vec(),
-                publisher: None,
-                expires: None,
-            })
-            .await?;
-        tracing::info!("Stored 'cpu' record");
+    network
+        .store(libp2p::kad::Record {
+            key: libp2p::kad::RecordKey::new(&"cpu"),
+            value: "test".as_bytes().to_vec(),
+            publisher: None,
+            expires: None,
+        })
+        .await?;
+    tracing::info!("Stored 'cpu' record");
 
-        network.provide("cpu").await?;
-        tracing::info!("Provided 'cpu' service");
-
-        // Stream data to gateway
-        // let start_time = Instant::now();
-        // let mut streams: Vec<JoinHandle<Result<(), Box<dyn Error + Send + Sync>>>> = Vec::new();
-        // for i in 0..TASKS {
-        //     let network_clone = Arc::clone(&network);
-        //     streams.push(task::spawn(async move {
-        //         tracing::info!(i=%i, "Starting stream");
-
-        //         let mut stream = network_clone.stream(peer_id).await?;
-
-        //         let bytes = vec![0u8; GIGABYTE / TASKS];
-
-        //         stream.write_all(&bytes).await?;
-        //         stream.close().await.ok();
-
-        //         Ok(())
-        //     }))
-        // }
-
-        // let _ = join_all(streams).await;
-
-        // // Record the elapsed time after the transfer
-        // let duration = start_time.elapsed();
-        // tracing::info!("Transferred {:?} in {:?}", GIGABYTE, duration);
-
-        // // Optionally, compute throughput (e.g., in MB/s)
-        // let seconds = duration.as_secs_f64();
-        // let throughput = (GIGABYTE as f64) / seconds / (1024.0 * 1024.0);
-        // tracing::info!("Throughput: {:.2} MB/s", throughput);
-
-        // Wait for Ctrl+C signal
-        tokio::signal::ctrl_c().await?;
-
-        // Signal shutdown
-        tracing::info!("Shutting down...");
-        let _ = shutdown_tx.send(());
-
-        Ok(())
-    });
-
-    tokio::select! {
-        _ = local => {
-            tracing::info!("LocalSet completed");
-        },
-        result = main_task => {
-            match result {
-                Ok(inner_result) => {
-                    if let Err(e) = inner_result {
-                        tracing::error!("Main task error: {:?}", e);
-                    }
-                },
-                Err(e) => {
-                    tracing::error!("Main task panicked: {:?}", e);
-                }
-            }
-        }
+    let messages = network.subscribe("messages").await?;
+    let mut messages = messages;
+    while let Some(message) = messages.next().await {
+        tracing::info!("Received message: {:?}", message);
     }
 
-    tracing::info!("Shutdown complete");
     Ok(())
 }


### PR DESCRIPTION
Adds gossipsub support to the network layer.
As an example, the scheduler pushed a message to the worker using gossipsub. Behaviours have been refactored for simpler usage. Furthermore, scheduler and worker needs to listen on a port to be able to participate in gossipsub.