### PR TITLE
feat: request-response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -373,6 +373,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -933,9 +960,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -951,6 +978,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1075,17 +1112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1203,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypha-api"
+version = "0.0.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "hypha-gateway"
 version = "0.0.0"
 dependencies = [
@@ -1197,6 +1230,7 @@ name = "hypha-network"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "ciborium",
  "futures-util",
  "libp2p",
  "libp2p-stream",
@@ -1215,6 +1249,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures-util",
+ "hypha-api",
  "hypha-network",
  "libp2p",
  "libp2p-stream",
@@ -1231,6 +1266,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures-util",
+ "hypha-api",
  "hypha-network",
  "libp2p",
  "libp2p-stream",
@@ -1441,7 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2007,7 +2043,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2604,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2714,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2767,12 +2803,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
-dependencies = [
- "hostname",
-]
+checksum = "fc7c8f7f733062b66dc1c63f9db168ac0b97a9210e247fa90fdc9ad08f51b302"
 
 [[package]]
 name = "ring"
@@ -2851,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -2864,14 +2897,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.2",
  "subtle",
  "zeroize",
 ]
@@ -2897,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2975,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3089,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3134,7 +3167,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3252,9 +3285,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3666,12 +3699,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "crates/api",
     "crates/gateway",
     "crates/network",
     "crates/scheduler",
@@ -56,4 +57,5 @@ mockall = "0.13.1"
 proptest = "1.6.0"
 
 # Hypha
+hypha-api = { path = "crates/api" }
 hypha-network = { path = "crates/network" }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hypha-api"
+version = "0.0.0"
+publish.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+
+[dependencies]
+serde.workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Request {
+    Work(),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Response {
+    WorkDone(),
+}

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tokio-stream.workspace = true
+ciborium = "0.2.2"
 
 [dev-dependencies]
 mockall.workspace = true

--- a/crates/network/src/cbor_codec.rs
+++ b/crates/network/src/cbor_codec.rs
@@ -1,0 +1,113 @@
+use std::{io, marker::PhantomData};
+
+use async_trait::async_trait;
+use futures_util::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use libp2p::{StreamProtocol, request_response};
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Codec for CBOR serialization and deserialization.
+///
+/// While `libp2p` provives a CBOR codec, it is a private implementation.
+/// We need a public one to use it as parameter in `request_response.rs`
+pub struct Codec<Req, Resp> {
+    request_size_maximum: u64,
+    response_size_maximum: u64,
+    phantom: PhantomData<(Req, Resp)>,
+}
+
+impl<Req, Resp> Default for Codec<Req, Resp> {
+    fn default() -> Self {
+        Self {
+            request_size_maximum: 1024 * 1024,
+            response_size_maximum: 10 * 1024 * 1024,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<Req, Resp> Clone for Codec<Req, Resp> {
+    fn clone(&self) -> Self {
+        Self {
+            request_size_maximum: self.request_size_maximum,
+            response_size_maximum: self.response_size_maximum,
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<Req, Resp> request_response::Codec for Codec<Req, Resp>
+where
+    Req: Send + Serialize + DeserializeOwned,
+    Resp: Send + Serialize + DeserializeOwned,
+{
+    type Protocol = StreamProtocol;
+    type Request = Req;
+    type Response = Resp;
+
+    async fn read_request<T>(&mut self, _: &Self::Protocol, io: &mut T) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let mut data = Vec::new();
+        io.take(self.request_size_maximum)
+            .read_to_end(&mut data)
+            .await?;
+
+        ciborium::from_reader(data.as_slice())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        let mut data = Vec::new();
+        io.take(self.response_size_maximum)
+            .read_to_end(&mut data)
+            .await?;
+
+        ciborium::from_reader(data.as_slice())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+        req: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        let mut data = Vec::new();
+        ciborium::into_writer(&req, &mut data)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        io.write_all(data.as_ref()).await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _: &Self::Protocol,
+        io: &mut T,
+        res: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        let mut data = Vec::new();
+        ciborium::into_writer(&res, &mut data)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        io.write_all(data.as_ref()).await?;
+
+        Ok(())
+    }
+}

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod cbor_codec;
 pub mod dial;
 pub mod error;
 pub mod gossipsub;
 pub mod kad;
 pub mod listen;
+pub mod request_response;
 pub mod stream;
 pub mod swarm;
 pub mod utils;

--- a/crates/network/src/request_response.rs
+++ b/crates/network/src/request_response.rs
@@ -1,0 +1,272 @@
+use std::{collections::HashMap, error::Error, fmt::Display};
+
+use libp2p::{PeerId, request_response, swarm::NetworkBehaviour};
+use tokio::sync::oneshot;
+
+use crate::swarm::SwarmDriver;
+
+pub type OutboundRequests<TCodec> = HashMap<
+    request_response::OutboundRequestId,
+    oneshot::Sender<Result<<TCodec as request_response::Codec>::Response, RequestResponseError>>,
+>;
+pub type OutboundResponses =
+    HashMap<request_response::InboundRequestId, oneshot::Sender<Result<(), RequestResponseError>>>;
+
+pub trait RequestResponseBehaviour<TCodec>
+where
+    TCodec: request_response::Codec + Clone + Send + 'static,
+{
+    fn request_response(&mut self) -> &mut request_response::Behaviour<TCodec>;
+}
+
+pub enum RequestResponseAction<TCodec>
+where
+    TCodec: request_response::Codec + Clone + Send + 'static,
+{
+    OutboundRequest(
+        PeerId,
+        <TCodec as request_response::Codec>::Request,
+        oneshot::Sender<
+            Result<<TCodec as request_response::Codec>::Response, RequestResponseError>,
+        >,
+    ),
+    OutboundResponse(
+        request_response::InboundRequestId,
+        request_response::ResponseChannel<<TCodec as request_response::Codec>::Response>,
+        <TCodec as request_response::Codec>::Response,
+        oneshot::Sender<Result<(), RequestResponseError>>,
+    ),
+}
+
+pub enum RequestResponseEvent<TCodec>
+where
+    TCodec: request_response::Codec + Clone + Send + 'static,
+{
+    InboundRequest(
+        request_response::InboundRequestId,
+        request_response::ResponseChannel<<TCodec as request_response::Codec>::Response>,
+        <TCodec as request_response::Codec>::Request,
+    ),
+}
+
+#[derive(Debug)]
+pub enum RequestResponseError {
+    Request(request_response::OutboundFailure),
+    Response(request_response::InboundFailure),
+    Other(String),
+}
+
+impl Error for RequestResponseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RequestResponseError::Request(err) => Some(err),
+            RequestResponseError::Response(err) => Some(err),
+            RequestResponseError::Other(_) => None,
+        }
+    }
+}
+
+impl Display for RequestResponseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestResponseError::Request(err) => write!(f, "Request error: {}", err),
+            RequestResponseError::Response(err) => write!(f, "Response error: {}", err),
+            RequestResponseError::Other(msg) => write!(f, "Other error: {}", msg),
+        }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait RequestResponseDriver<TBehaviour, TCodec>: SwarmDriver<TBehaviour>
+where
+    TBehaviour: NetworkBehaviour + RequestResponseBehaviour<TCodec>,
+    TCodec: request_response::Codec + Clone + Send + 'static,
+{
+    async fn send(&mut self, event: RequestResponseEvent<TCodec>);
+
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<TCodec>;
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses;
+
+    async fn process_request_response_action(&mut self, action: RequestResponseAction<TCodec>) {
+        match action {
+            RequestResponseAction::OutboundRequest(peer_id, request, tx) => {
+                let request_id = self
+                    .swarm()
+                    .behaviour_mut()
+                    .request_response()
+                    .send_request(&peer_id, request);
+                self.outbound_requests().insert(request_id, tx);
+            }
+            RequestResponseAction::OutboundResponse(request_id, ch, response, tx) => {
+                match self
+                    .swarm()
+                    .behaviour_mut()
+                    .request_response()
+                    .send_response(ch, response)
+                {
+                    Ok(()) => {
+                        self.outbound_responses().insert(request_id, tx);
+                    }
+                    Err(_) => {
+                        let _ = tx.send(Err(RequestResponseError::Other(
+                            "Response channel closed".to_string(),
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn process_request_response_event(
+        &mut self,
+        event: request_response::Event<
+            <TCodec as request_response::Codec>::Request,
+            <TCodec as request_response::Codec>::Response,
+        >,
+    ) {
+        match event {
+            request_response::Event::Message { message, .. } => match message {
+                request_response::Message::Request {
+                    request_id,
+                    request,
+                    channel,
+                } => {
+                    self.send(RequestResponseEvent::InboundRequest(
+                        request_id, channel, request,
+                    ))
+                    .await;
+                }
+                request_response::Message::Response {
+                    request_id,
+                    response,
+                } => {
+                    if let Some(tx) = self.outbound_requests().remove(&request_id) {
+                        let _ = tx.send(Ok(response));
+                    } else {
+                        tracing::warn!("No sender for request id: {:?}", request_id);
+                    }
+                }
+            },
+            request_response::Event::ResponseSent { request_id, .. } => {
+                if let Some(tx) = self.outbound_responses().remove(&request_id) {
+                    let _ = tx.send(Ok(()));
+                } else {
+                    tracing::warn!("No sender for request id: {:?}", request_id);
+                }
+            }
+            request_response::Event::InboundFailure {
+                request_id, error, ..
+            } => {
+                if let Some(tx) = self.outbound_responses().remove(&request_id) {
+                    let _ = tx.send(Err(RequestResponseError::Response(error)));
+                } else {
+                    tracing::warn!("No sender for request id: {:?}", request_id);
+                }
+            }
+            request_response::Event::OutboundFailure {
+                request_id, error, ..
+            } => {
+                if let Some(tx) = self.outbound_requests().remove(&request_id) {
+                    let _ = tx.send(Err(RequestResponseError::Request(error)));
+                } else {
+                    tracing::warn!("No sender for request id: {:?}", request_id);
+                }
+            }
+        }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait RequestResponseInterface<TCodec>
+where
+    TCodec: request_response::Codec + Clone + Send + 'static,
+{
+    async fn send(&self, action: RequestResponseAction<TCodec>);
+
+    async fn request(
+        &self,
+        peer_id: PeerId,
+        request: <TCodec as request_response::Codec>::Request,
+    ) -> Result<<TCodec as request_response::Codec>::Response, RequestResponseError> {
+        let (tx, rx) = oneshot::channel();
+        self.send(RequestResponseAction::OutboundRequest(peer_id, request, tx))
+            .await;
+        rx.await.unwrap()
+    }
+
+    async fn response(
+        &self,
+        request_id: request_response::InboundRequestId,
+        ch: request_response::ResponseChannel<<TCodec as request_response::Codec>::Response>,
+        response: <TCodec as request_response::Codec>::Response,
+    ) -> Result<(), RequestResponseError> {
+        let (tx, rx) = oneshot::channel();
+        self.send(RequestResponseAction::OutboundResponse(
+            request_id, ch, response, tx,
+        ))
+        .await;
+        rx.await.unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::mock;
+    use serde::{Deserialize, Serialize};
+
+    use crate::cbor_codec::Codec;
+
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Request {
+        value: String,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Response {
+        value: String,
+    }
+
+    mock! {
+        TestInterface {}
+
+        impl RequestResponseInterface<Codec<Request, Response>> for TestInterface {
+            async fn send(&self, action: RequestResponseAction<Codec<Request, Response>>);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_requestresponse_interface_request() {
+        let mut mock = MockTestInterface::new();
+
+        mock.expect_send()
+            .withf(|action| matches!(action, RequestResponseAction::OutboundRequest(_, _, _)))
+            .times(1)
+            .returning(move |action| match action {
+                RequestResponseAction::OutboundRequest(_, Request { value }, tx) => {
+                    if value == "test".to_string() {
+                        let _ = tx.send(Ok(Response {
+                            value: "test".to_string(),
+                        }));
+                    }
+                }
+                _ => {}
+            });
+
+        let response = mock
+            .request(
+                PeerId::random(),
+                Request {
+                    value: "test".to_string(),
+                },
+            )
+            .await;
+
+        assert!(response.is_ok());
+        let response = response.unwrap();
+
+        assert!(response.value == "test".to_string());
+    }
+}

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -15,4 +15,5 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+hypha-api.workspace = true
 hypha-network.workspace = true

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -1,21 +1,27 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use futures_util::stream::StreamExt;
 use hypha_network::{
+    cbor_codec,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
     error::HyphaError,
     gossipsub::{
-        GossipsubAction, GossipsubBehaviour, GossipsubDriver, GossipsubInterface, Subscriptions,
+        GossipsubAction, GossipsubBehaviour, GossipsubDriver, GossipsubEvent, GossipsubInterface,
+        Subscriptions,
     },
     kad::{
         KademliaAction, KademliaBehavior, KademliaDriver, KademliaInterface, KademliaResult,
         PendingQueries,
     },
     listen::{ListenAction, ListenDriver, ListenInterface, PendingListens},
+    request_response::{
+        OutboundRequests, OutboundResponses, RequestResponseAction, RequestResponseBehaviour,
+        RequestResponseDriver, RequestResponseEvent, RequestResponseInterface,
+    },
     stream::{StreamInterface, StreamSenderInterface},
     swarm::SwarmDriver,
 };
-use libp2p::PeerId;
+use libp2p::{PeerId, StreamProtocol, request_response};
 use libp2p::{
     Swarm, SwarmBuilder, gossipsub, identify, identity, kad, ping,
     swarm::{ConnectionId, DialError, NetworkBehaviour, SwarmEvent},
@@ -24,7 +30,6 @@ use libp2p::{
 use libp2p_stream as stream;
 use tokio::sync::{mpsc, oneshot};
 
-#[derive(Clone)]
 pub(crate) struct Network {
     action_sender: mpsc::Sender<Action>,
     stream_control: stream::Control,
@@ -37,6 +42,8 @@ pub(crate) struct Behaviour {
     stream: stream::Behaviour,
     kademlia: kad::Behaviour<kad::store::MemoryStore>,
     gossipsub: gossipsub::Behaviour,
+    request_response:
+        request_response::Behaviour<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>,
 }
 
 pub(crate) struct NetworkDriver {
@@ -45,7 +52,11 @@ pub(crate) struct NetworkDriver {
     pending_listen_map: PendingListens,
     pending_queries_map: PendingQueries,
     subscriptions: Subscriptions,
+    outbound_requests_map:
+        OutboundRequests<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>,
+    outbound_responses_map: OutboundResponses,
     action_receiver: mpsc::Receiver<Action>,
+    event_sender: mpsc::Sender<Event>,
 }
 
 enum Action {
@@ -53,11 +64,25 @@ enum Action {
     Listen(ListenAction),
     Kademlia(KademliaAction),
     Gossipsub(GossipsubAction),
+    RequestResponse(
+        RequestResponseAction<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>,
+    ),
+}
+
+pub enum Event {
+    #[allow(dead_code)]
+    Gossipsub(GossipsubEvent),
+    RequestResponse(
+        RequestResponseEvent<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>,
+    ),
 }
 
 impl Network {
-    pub fn create(identity: identity::Keypair) -> Result<(Self, NetworkDriver), HyphaError> {
+    pub fn create(
+        identity: identity::Keypair,
+    ) -> Result<(Self, NetworkDriver, mpsc::Receiver<Event>), HyphaError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
+        let (event_sender, event_receiver) = mpsc::channel(5);
 
         let swarm = SwarmBuilder::with_existing_identity(identity)
             .with_tokio()
@@ -84,6 +109,15 @@ impl Network {
                     gossipsub::Config::default(),
                 )
                 .unwrap(),
+                request_response: request_response::Behaviour::<
+                    cbor_codec::Codec<hypha_api::Request, hypha_api::Response>,
+                >::new(
+                    [(
+                        StreamProtocol::new("/hypha-api/0.0.1"),
+                        request_response::ProtocolSupport::Full,
+                    )],
+                    request_response::Config::default(),
+                ),
             })
             .map_err(|_| HyphaError::SwarmError("Failed to create swarm behavior.".to_string()))?
             .build();
@@ -98,9 +132,13 @@ impl Network {
                 pending_dials_map: HashMap::default(),
                 pending_listen_map: HashMap::default(),
                 pending_queries_map: HashMap::default(),
-                subscriptions: HashMap::default(),
+                subscriptions: HashSet::default(),
+                outbound_requests_map: HashMap::default(),
+                outbound_responses_map: HashMap::default(),
                 action_receiver,
+                event_sender,
             },
+            event_receiver,
         ))
     }
 }
@@ -135,7 +173,10 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                              self.process_kademlia_query_result(id, result, step).await;
                         }
                         SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(event)) => {
-                        self.process_gossipsub_event(event).await;
+                            self.process_gossipsub_event(event).await;
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(event)) => {
+                            self.process_request_response_event(event).await;
                         }
                         _ => {
                             tracing::debug!("Unhandled event: {:?}", event);
@@ -144,18 +185,11 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                 },
                 Some(action) = self.action_receiver.recv() => {
                     match action {
-                        Action::Dial(action) => {
-                            self.process_dial_action(action).await;
-                        }
-                        Action::Listen(action) => {
-                            self.process_listen_action(action).await;
-                        }
-                        Action::Kademlia(action) => {
-                            self.process_kademlia_action(action).await;
-                        }
-                        Action::Gossipsub(action) => {
-                            self.process_gossipsub_action(action).await;
-                        }
+                        Action::Dial(action) => self.process_dial_action(action).await,
+                        Action::Listen(action) => self.process_listen_action(action).await,
+                        Action::Kademlia(action) => self.process_kademlia_action(action).await,
+                        Action::Gossipsub(action) => self.process_gossipsub_action(action).await,
+                        Action::RequestResponse(action) => self.process_request_response_action(action).await,
                     }
                 },
                 else => break
@@ -236,6 +270,13 @@ impl GossipsubBehaviour for Behaviour {
 }
 
 impl GossipsubDriver<Behaviour> for NetworkDriver {
+    async fn send(&mut self, event: GossipsubEvent) {
+        self.event_sender
+            .send(Event::Gossipsub(event))
+            .await
+            .unwrap();
+    }
+
     fn subscriptions(&mut self) -> &mut Subscriptions {
         &mut self.subscriptions
     }
@@ -245,6 +286,55 @@ impl GossipsubInterface for Network {
     async fn send(&self, action: GossipsubAction) {
         self.action_sender
             .send(Action::Gossipsub(action))
+            .await
+            .unwrap();
+    }
+}
+
+impl RequestResponseBehaviour<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>
+    for Behaviour
+{
+    fn request_response(
+        &mut self,
+    ) -> &mut request_response::Behaviour<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>
+    {
+        &mut self.request_response
+    }
+}
+
+impl RequestResponseDriver<Behaviour, cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>
+    for NetworkDriver
+{
+    async fn send(
+        &mut self,
+        event: RequestResponseEvent<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>,
+    ) {
+        self.event_sender
+            .send(Event::RequestResponse(event))
+            .await
+            .unwrap();
+    }
+
+    fn outbound_requests(
+        &mut self,
+    ) -> &mut OutboundRequests<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>> {
+        &mut self.outbound_requests_map
+    }
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses {
+        &mut self.outbound_responses_map
+    }
+}
+
+impl RequestResponseInterface<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>
+    for Network
+{
+    async fn send(
+        &self,
+        action: RequestResponseAction<cbor_codec::Codec<hypha_api::Request, hypha_api::Response>>,
+    ) {
+        self.action_sender
+            .send(Action::RequestResponse(action))
             .await
             .unwrap();
     }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -15,4 +15,5 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+hypha-api.workspace = true
 hypha-network.workspace = true


### PR DESCRIPTION
Adds request-response support to the network layer.
In contrast to the existing protocols, inbound requests are independent
from any application actions. Therefore, we introduce network events to
be able to handle inbound requests. Applications add their
application-logic for handling these events.
The gossipsub protocol has been updated to emit these events for
subscribed messages. This removes the need for the separate
`tokio::sync::broacast` channel used before.