### PR TITLE
docs: improve documentation and document standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,22 @@ license = "${TYPE}"
 
 The default license is Apache-2.0, but the project uses multiple licenses for the time being. If you're uncertain about which license to use, please consult the project lead. Make sure to use the SPDF license identifier, see  https://spdx.org/licenses/ for more information.
 
+## Documentation
+
+All user-facing features MUST be documented. Good documentation is crucial to making making large-scale machine learning accessible. Quality documentation removes barriers and enables widespread innovation by ensuring users can effectively understand and utilize the system.
+
+Each crate MUST begin with comprehensive front-page documentation in `lib.rs` and SHOULD including an introduction, quick start example, feature overview, and integration guide. Every public function, struct, enum, trait, and module MUST be documented with `///` comments that describe their purpose and SHOULD document include usage examples.
+
+All Documentation SHOULD be:
+- **Clear and concise** - Easy to understand for the target audience
+- **Complete** - Covering all public functionality comprehensively
+- **Current** - Updated with every change
+- **Consistent** - Following project-wide style and conventions
+
+Poor or missing documentation for user-facing features will block pull requests. When in doubt, err on the side of more documentation rather than less.
+
+For detailed guidelines, refer to the [rustdoc book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+
 ### Adding Dependencies
 
 When adding dependencies, these MUST be added to the respective crate's `Cargo.toml` file. You can add dependencies using:
@@ -108,6 +124,7 @@ Make sure that the dependency is compatible with the project's licenses.
 All dependencies SHALL be updated regularly to maintain an up to date and secure product. Updates SHOULD consider backward compatibility and MUST document compatibility issues.
 
 <!-- TODO: Setup dependabot for automatic dependency updates and security updates and document configuration. -->
+
 
 ## Version Control
 

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1,3 +1,5 @@
+//! Gateway binary.
+
 mod network;
 
 use std::{error::Error, fs, net::SocketAddr, path::PathBuf};

--- a/crates/gateway/src/network.rs
+++ b/crates/gateway/src/network.rs
@@ -1,3 +1,8 @@
+//! Networking utilities for the gateway component.
+//!
+//! This module wires together the various networking primitives to run the
+//! gateway's event loop.
+
 use std::collections::HashMap;
 
 use futures_util::stream::StreamExt;

--- a/crates/network/src/dial.rs
+++ b/crates/network/src/dial.rs
@@ -1,3 +1,9 @@
+//! Handles outbound dialing to peers.
+//!
+//! This module abstracts the details of initiating connections and tracking
+//! pending dials. It provides traits for dialing behavior implementations
+//! and helpers to manage asynchronous dialing responses.
+
 use std::collections::HashMap;
 
 use libp2p::{
@@ -8,18 +14,48 @@ use tokio::sync::oneshot;
 
 use crate::swarm::SwarmDriver;
 
+/// Type alias for tracking pending dial operations.
+///
+/// Maps connection IDs to response channels that will receive the dial result
+/// once the connection attempt completes (either successfully or with an error).
 pub type PendingDials = HashMap<ConnectionId, oneshot::Sender<Result<PeerId, DialError>>>;
 
+/// Actions that can be sent to a dial driver for processing.
+///
+/// These actions represent dial-related operations that need to be handled
+/// by the network event loop. Each action includes the necessary data and
+/// a response channel to communicate the result back to the caller.
 pub enum DialAction {
+    /// Initiate a dial to the specified multiaddress.
+    ///
+    /// The sender will receive the result of the dial attempt, containing
+    /// either the successfully connected peer ID or a dial error.
     Dial(Multiaddr, oneshot::Sender<Result<PeerId, DialError>>),
 }
 
+/// Trait for handling outbound dial operations within a swarm driver.
+///
+/// This trait extends [`SwarmDriver`] to provide dial-specific functionality.
+/// Implementations should track pending dials and process dial-related events
+/// from the libp2p swarm.
 pub trait DialDriver<TBehavior>: SwarmDriver<TBehavior> + Send
 where
     TBehavior: NetworkBehaviour,
 {
+    /// Returns a mutable reference to the pending dials tracker.
+    ///
+    /// This is used to store and retrieve dial response channels while
+    /// connection attempts are in progress.
     fn pending_dials(&mut self) -> &mut PendingDials;
 
+    /// Process a dial action by initiating the connection attempt.
+    ///
+    /// This method handles [`DialAction::Dial`] by calling the libp2p swarm's
+    /// dial method and tracking the connection attempt for later completion.
+    ///
+    /// # Arguments
+    ///
+    /// * `action` - The dial action to process
     fn process_dial_action(&mut self, action: DialAction) -> impl Future<Output = ()> + Send {
         async move {
             match action {
@@ -38,6 +74,16 @@ where
         }
     }
 
+    /// Handle successful connection establishment.
+    ///
+    /// This should be called when a libp2p `ConnectionEstablished` event
+    /// is received. It notifies any pending dial operations that the
+    /// connection was successful.
+    ///
+    /// # Arguments
+    ///
+    /// * `peer_id` - The peer ID of the successfully connected peer
+    /// * `connection_id` - The connection ID of the established connection
     fn process_connection_established(
         &mut self,
         peer_id: PeerId,
@@ -50,6 +96,15 @@ where
         }
     }
 
+    /// Handle connection establishment errors.
+    ///
+    /// This should be called when a libp2p dial fails. It notifies any
+    /// pending dial operations about the failure.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection_id` - The connection ID of the failed connection attempt
+    /// * `error` - The dial error that occurred
     fn process_connection_error(
         &mut self,
         connection_id: &ConnectionId,
@@ -63,9 +118,70 @@ where
     }
 }
 
+/// Interface for sending dial actions to a network driver.
+///
+/// This trait provides a high-level API for dialing peers without needing
+/// to interact directly with the libp2p swarm. Implementations typically
+/// send actions through a channel to the network event loop.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use hypha_network::dial::{DialInterface, DialAction};
+/// use libp2p::Multiaddr;
+/// use tokio::sync::mpsc;
+///
+/// struct NetworkInterface {
+///     action_sender: mpsc::Sender<DialAction>,
+/// }
+///
+/// impl DialInterface for NetworkInterface {
+///     async fn send(&self, action: DialAction) {
+///         let _ = self.action_sender.send(action).await;
+///     }
+/// }
+///
+/// async fn example_usage(network: &NetworkInterface) {
+///     let addr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
+///     match network.dial(addr).await {
+///         Ok(peer_id) => println!("Connected to peer: {}", peer_id),
+///         Err(e) => println!("Dial failed: {}", e),
+///     }
+/// }
+/// ```
 pub trait DialInterface: Sync {
+    /// Send a dial action to the network driver.
+    ///
+    /// This is the low-level method for sending actions. Most users should
+    /// prefer the higher-level [`dial`](Self::dial) method.
     fn send(&self, action: DialAction) -> impl Future<Output = ()> + Send;
 
+    /// Dial a peer at the specified multiaddress.
+    ///
+    /// This method initiates a connection attempt to the given address and
+    /// waits for the result. It's a convenience wrapper around sending a
+    /// [`DialAction::Dial`] and waiting for the response.
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The multiaddress to dial
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(PeerId)` - The peer ID of the successfully connected peer
+    /// * `Err(DialError)` - The error that occurred during dialing
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use hypha_network::dial::DialInterface;
+    /// # async fn example(network: impl DialInterface) -> Result<(), libp2p::swarm::DialError> {
+    /// let addr = "/ip4/127.0.0.1/tcp/1234".parse().unwrap();
+    /// let peer_id = network.dial(addr).await?;
+    /// println!("Connected to: {}", peer_id);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn dial(&self, address: Multiaddr) -> impl Future<Output = Result<PeerId, DialError>> + Send {
         async move {
             let (tx, rx) = oneshot::channel();

--- a/crates/network/src/gossipsub.rs
+++ b/crates/network/src/gossipsub.rs
@@ -1,3 +1,10 @@
+//! Abstractions over the libp2p gossipsub protocol.
+//!
+//! This module exposes traits and helpers to publish and subscribe to topics
+//! using gossipsub. It hides the underlying protocol details from the rest of
+//! the code base and provides typed channels for incoming and outgoing
+//! messages.
+
 use std::collections::HashMap;
 
 use libp2p::{gossipsub, swarm::NetworkBehaviour};
@@ -7,42 +14,97 @@ use tokio_stream::wrappers::BroadcastStream;
 
 use crate::swarm::SwarmDriver;
 
+/// Type alias for tracking active gossipsub subscriptions.
+///
+/// Maps topic hashes to broadcast channels that distribute incoming messages
+/// for that topic to all interested subscribers.
 pub type Subscriptions = HashMap<gossipsub::TopicHash, broadcast::Sender<Vec<u8>>>;
 
+/// Trait for network behaviours that include gossipsub functionality.
+///
+/// This trait provides access to the gossipsub behaviour within a composite
+/// network behaviour. It's used by other traits that need to interact with
+/// the gossipsub protocol.
 pub trait GossipsubBehaviour {
+    /// Returns a mutable reference to the gossipsub behaviour.
     fn gossipsub(&mut self) -> &mut gossipsub::Behaviour;
 }
 
+/// Actions that can be sent to a gossipsub driver for processing.
+///
+/// These actions represent gossipsub-related operations that need to be handled
+/// by the network event loop. Each action includes the necessary data and
+/// a response channel to communicate the result back to the caller.
 pub enum GossipsubAction {
+    /// Publish a message to the specified topic.
+    ///
+    /// The message data will be broadcast to all peers subscribed to the topic.
+    /// The sender will receive confirmation of successful publication or an error.
     Publish(
         gossipsub::IdentTopic,
         Vec<u8>,
         oneshot::Sender<Result<(), GossipsubError>>,
     ),
+
+    /// Subscribe to the specified topic.
+    ///
+    /// The sender will receive a broadcast receiver that can be used to
+    /// receive messages published to this topic.
     Subscribe(
         gossipsub::IdentTopic,
         oneshot::Sender<Result<broadcast::Receiver<Vec<u8>>, GossipsubError>>,
     ),
+
+    /// Unsubscribe from the specified topic.
+    ///
+    /// After unsubscribing, no new messages for this topic will be received.
+    /// The sender will receive confirmation of successful unsubscription.
     Unsubscribe(
         gossipsub::IdentTopic,
         oneshot::Sender<Result<(), GossipsubError>>,
     ),
 }
 
+/// Errors that can occur during gossipsub operations.
+///
+/// This enum wraps the various error types that can be returned by the
+/// libp2p gossipsub implementation, providing a unified error type for
+/// the Hypha network layer.
 #[derive(Debug, Error)]
 pub enum GossipsubError {
+    /// Error occurred during subscription or unsubscription operations.
     #[error("subscription error: {0}")]
     Subscription(#[from] gossipsub::SubscriptionError),
+
+    /// Error occurred during message publication.
     #[error("publish error: {0}")]
     Publish(#[from] gossipsub::PublishError),
 }
 
+/// Trait for handling gossipsub operations within a swarm driver.
+///
+/// This trait extends [`SwarmDriver`] to provide gossipsub-specific
+/// functionality. Implementations should track active subscriptions and
+/// process gossipsub-related events from the libp2p swarm.
 pub trait GossipsubDriver<TBehavior>: SwarmDriver<TBehavior> + Send
 where
     TBehavior: NetworkBehaviour + GossipsubBehaviour,
 {
+    /// Returns a mutable reference to the active subscriptions tracker.
+    ///
+    /// This is used to manage broadcast channels for distributing incoming
+    /// messages to subscribers.
     fn subscriptions(&mut self) -> &mut Subscriptions;
 
+    /// Process a gossipsub action by interacting with the gossipsub behaviour.
+    ///
+    /// This method handles all types of gossipsub actions including publishing,
+    /// subscribing, and unsubscribing. It manages the subscription state and
+    /// sends appropriate responses through the provided channels.
+    ///
+    /// # Arguments
+    ///
+    /// * `action` - The gossipsub action to process
     fn process_gossipsub_action(
         &mut self,
         action: GossipsubAction,
@@ -93,6 +155,15 @@ where
         }
     }
 
+    /// Handle incoming gossipsub events from the libp2p swarm.
+    ///
+    /// This method processes gossipsub events, particularly incoming messages,
+    /// and distributes them to the appropriate subscribers through broadcast
+    /// channels.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The gossipsub event to process
     fn process_gossipsub_event(
         &mut self,
         event: gossipsub::Event,
@@ -115,9 +186,65 @@ where
     }
 }
 
+/// Interface for sending gossipsub actions to a network driver.
+///
+/// This trait provides a high-level API for gossipsub operations without
+/// needing to interact directly with the libp2p swarm. Implementations
+/// typically send actions through a channel to the network event loop.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use hypha_network::gossipsub::{GossipsubInterface, GossipsubAction};
+/// use tokio_stream::StreamExt;
+///
+/// async fn example_usage(network: impl GossipsubInterface) {
+///     // Subscribe to a topic
+///     let mut stream = network.subscribe("my-topic").await.unwrap();
+///
+///     // Publish a message
+///     network.publish("my-topic", b"Hello, world!").await.unwrap();
+///
+///     // Receive the message
+///     if let Some(Ok(message)) = stream.next().await {
+///         println!("Received: {:?}", message);
+///     }
+/// }
+/// ```
 pub trait GossipsubInterface: Sync {
+    /// Send a gossipsub action to the network driver.
+    ///
+    /// This is the low-level method for sending actions. Most users should
+    /// prefer the higher-level methods like [`publish`](Self::publish),
+    /// [`subscribe`](Self::subscribe), and [`unsubscribe`](Self::unsubscribe).
     fn send(&self, action: GossipsubAction) -> impl Future<Output = ()> + Send;
 
+    /// Subscribe to a gossipsub topic.
+    ///
+    /// This method subscribes to the specified topic and returns a stream
+    /// that will receive all messages published to that topic.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name to subscribe to
+    ///
+    /// # Returns
+    ///
+    /// A stream of message data for the subscribed topic.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use hypha_network::gossipsub::GossipsubInterface;
+    /// # use tokio_stream::StreamExt;
+    /// # async fn example(network: impl GossipsubInterface) -> Result<(), hypha_network::gossipsub::GossipsubError> {
+    /// let mut stream = network.subscribe("chat").await?;
+    /// while let Some(Ok(message)) = stream.next().await {
+    ///     println!("Chat message: {:?}", String::from_utf8_lossy(&message));
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     fn subscribe(
         &self,
         topic: &str,
@@ -137,6 +264,25 @@ pub trait GossipsubInterface: Sync {
         }
     }
 
+    /// Unsubscribe from a gossipsub topic.
+    ///
+    /// This method unsubscribes from the specified topic. After unsubscribing,
+    /// no new messages for this topic will be received.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name to unsubscribe from
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use hypha_network::gossipsub::GossipsubInterface;
+    /// # async fn example(network: impl GossipsubInterface) -> Result<(), hypha_network::gossipsub::GossipsubError> {
+    /// network.unsubscribe("old-topic").await?;
+    /// println!("Unsubscribed from old-topic");
+    /// # Ok(())
+    /// # }
+    /// ```
     fn unsubscribe(&self, topic: &str) -> impl Future<Output = Result<(), GossipsubError>> + Send {
         async move {
             let (tx, rx) = oneshot::channel();
@@ -150,6 +296,29 @@ pub trait GossipsubInterface: Sync {
         }
     }
 
+    /// Publish a message to a gossipsub topic.
+    ///
+    /// This method publishes the provided data to all peers subscribed to
+    /// the specified topic.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The topic name to publish to
+    /// * `data` - The data to publish (anything that can be converted to `Vec<u8>`)
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use hypha_network::gossipsub::GossipsubInterface;
+    /// # async fn example(network: impl GossipsubInterface) -> Result<(), hypha_network::gossipsub::GossipsubError> {
+    /// // Publish a string message
+    /// network.publish("chat", "Hello, everyone!").await?;
+    ///
+    /// // Publish binary data
+    /// network.publish("data", vec![1, 2, 3, 4]).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     fn publish<T>(
         &self,
         topic: &str,

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -1,3 +1,39 @@
+#![deny(missing_docs)]
+//! Networking primitives used across Hypha.
+//!
+//! The `hypha-network` crate provides a lightweight abstraction over the
+//! [`libp2p`](https://libp2p.io) stack so that higher level components can
+//! focus on their business logic. It defines traits and helper utilities for
+//! common behaviours such as dialing, listening, gossipsub messaging,
+//! Kademlia DHT operations, and custom stream protocols.
+//!
+//! # Features
+//!
+//! ## Core Components
+//!
+//! - **[`swarm`]**: Base trait for managing libp2p swarm operations
+//! - **[`dial`]**: Outbound connection management and peer dialing
+//! - **[`listen`]**: Inbound connection handling and listening
+//! - **[`gossipsub`]**: Publish-subscribe messaging over gossipsub protocol
+//! - **[`kad`]**: Kademlia DHT operations for peer discovery and routing
+//! - **[`request_response`]**: Request-response messaging between peers
+//! - **[`stream`]**: Custom streaming protocols for data transfer
+//! - **[`cert`]**: Certificate handling
+//! - **[`mtls`]**: mTLS functionality for libp2p
+//! - **[`utils`]**: Utility functions and common operations
+//!
+//! # Integration Guide
+//!
+//! To integrate the network crate into your application:
+//!
+//! 1. Define your custom `NetworkBehaviour` that implements the required traits
+//! 2. Use the driver traits ([`swarm::SwarmDriver`], [`dial::DialDriver`], etc.) in your event loop
+//! 3. Expose interface traits ([`dial::DialInterface`], [`listen::ListenInterface`], etc.) to application logic
+//! 4. Handle network events asynchronously using the provided action types
+//!
+//! Each module contains detailed examples and usage patterns for specific
+//! networking functionality.
+
 pub mod cert;
 pub mod dial;
 pub mod gossipsub;

--- a/crates/network/src/mtls.rs
+++ b/crates/network/src/mtls.rs
@@ -1,3 +1,8 @@
+//! mTLS functionality for 'libp2p'.
+//!
+//! Provides mutual TLS for 'libp2p' by providing a `Config` that can be used for the
+//! `security_upgrade` parameter when using `SwarmBuilder`.
+
 use std::{
     io,
     net::{IpAddr, Ipv4Addr},
@@ -19,7 +24,9 @@ use webpki::EndEntityCert;
 
 /// Unified TLS stream that can be either a client or server stream
 pub enum TlsStream<T> {
+    /// A client TLS stream
     Client(futures_rustls::client::TlsStream<T>),
+    /// A server TLS stream
     Server(futures_rustls::server::TlsStream<T>),
 }
 
@@ -69,22 +76,30 @@ where
     }
 }
 
+/// Error type for mTLS configuration and upgrade failures.
 #[derive(Error, Debug)]
 pub enum UpgradeError {
+    /// Failed to upgrade server connection.
     #[error("Failed to upgrade server connection: {0}")]
     ServerUpgrade(io::Error),
+    /// Failed to upgrade client connection.
     #[error("Failed to upgrade client connection: {0}")]
     ClientUpgrade(io::Error),
+    /// Failed to configure TLS.
     #[error("Failed to configure TLS: {0}")]
     TlsConfiguration(String),
+    /// No peer certificate found.
     #[error("No peer certificate found")]
     NoPeerCertificate,
+    /// Failed to decode public key.
     #[error("Failed to decode public key from DER: {0}")]
     SPKIError(#[from] ed25519_dalek::pkcs8::spki::Error),
+    /// Failed to convert to Ed25519 public key.
     #[error("Failed to convert to Ed25519 public key: {0}")]
     DecodingError(#[from] libp2p::identity::DecodingError),
 }
 
+/// A mTLS configuration.
 #[derive(Clone)]
 pub struct Config {
     server: ServerConfig,

--- a/crates/network/src/stream.rs
+++ b/crates/network/src/stream.rs
@@ -1,21 +1,78 @@
+//! Streaming utilities over libp2p.
+//!
+//! Defines traits for sending and receiving custom stream protocols. The current
+//! implementation focuses on a tensor streaming protocol but can be extended to
+//! other data types in the future.
+
 // TODO: Decide whether to model this as an abstract stream interface with the protocol identifier as an argument or
 
 use libp2p::{PeerId, Stream, StreamProtocol};
 use libp2p_stream::{AlreadyRegistered, Control, IncomingStreams, OpenStreamError};
 
+/// The protocol identifier for Hypha's tensor streaming protocol.
+///
+/// This constant defines the libp2p protocol string used for tensor data streaming
+/// between peers. It follows the libp2p convention of using a path-like identifier.
 const TENSOR_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/hypha-tensor-stream");
 
+/// Base trait for accessing libp2p stream control functionality.
+///
+/// This trait provides access to the libp2p-stream `Control` object, which
+/// is used to manage custom streaming protocols. It serves as the foundation
+/// for both sending and receiving stream interfaces.
 pub trait StreamInterface {
+    /// Returns the stream control handle.
+    ///
+    /// This provides access to the libp2p-stream control interface for
+    /// managing custom protocols and stream operations.
     fn stream_control(&self) -> Control;
 }
 
+/// Trait for receiving incoming streams on the tensor protocol.
+///
+/// This trait extends [`StreamInterface`] to provide functionality for
+/// accepting incoming streams from other peers. It handles the protocol
+/// registration and provides access to the stream of incoming connections.
 pub trait StreamReceiverInterface: StreamInterface {
+    /// Accept incoming streams.
+    ///
+    /// This method registers the streaming protocol and returns a stream
+    /// of incoming connections from other peers wanting to send data.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(IncomingStreams)` - A stream of incoming connections
+    /// * `Err(AlreadyRegistered)` - The protocol was already registered
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AlreadyRegistered`] if the protocol has already been
+    /// registered with the stream control.
     fn streams(&self) -> Result<IncomingStreams, AlreadyRegistered> {
         self.stream_control().accept(TENSOR_STREAM_PROTOCOL)
     }
 }
 
+/// Trait for sending outgoing streams on the protocol.
+///
+/// This trait extends [`StreamInterface`] to provide functionality for opening
+/// outgoing tensor streams to other peers. It handles the protocol negotiation
+/// and stream establishment.
 pub trait StreamSenderInterface: StreamInterface + Sync {
+    /// Open a tensor stream to a specific peer.
+    ///
+    /// This method establishes a direct streaming connection to the specified
+    /// peer using the tensor streaming protocol. The resulting stream can be
+    /// used to send tensor data efficiently.
+    ///
+    /// # Arguments
+    ///
+    /// * `peer_id` - The peer ID to establish a stream connection with
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Stream)` - A successfully opened stream to the peer
+    /// * `Err(OpenStreamError)` - An error occurred during stream establishment
     fn stream(
         &self,
         peer_id: PeerId,

--- a/crates/network/src/swarm.rs
+++ b/crates/network/src/swarm.rs
@@ -1,24 +1,52 @@
+//! Trait wrappers around the libp2p `Swarm`.
+//!
+//! Provides a minimal interface for running the swarm and retrieving mutable
+//! access to it. Higher level components implement these traits to drive the
+//! networking event loop.
+
 use libp2p::{Swarm, swarm::NetworkBehaviour};
 use thiserror::Error;
 
+/// Errors that can occur during swarm operations and configuration.
 #[derive(Debug, Error)]
 pub enum SwarmError {
+    /// Transport layer configuration failed.
     #[error("Transport configuration failed: {0}")]
     TransportConfig(String),
+    /// Network behaviour instantiation failed.
     #[error("Behaviour creation failed: {0}")]
     BehaviourCreation(String),
+    /// Swarm-level configuration failed.
     #[error("Swarm configuration failed: {0}")]
     SwarmConfig(String),
 }
 
+/// Base trait for managing a libp2p swarm and driving network operations.
+///
+/// This trait provides the foundational interface for all network drivers in the
+/// Hypha network stack. It gives access to the underlying libp2p swarm and defines
+/// the main event loop for processing network events.
 #[allow(async_fn_in_trait)]
 pub trait SwarmDriver<TBehavior>
 where
     TBehavior: NetworkBehaviour,
     Self: Sized,
 {
+    /// Returns a mutable reference to the underlying libp2p swarm.
+    ///
+    /// This provides direct access to the swarm for advanced operations
+    /// that are not covered by the higher-level trait methods.
     fn swarm(&mut self) -> &mut Swarm<TBehavior>;
 
     /// Run the swarm driver, processing incoming actions and managing the swarm.
+    ///
+    /// This is the main event loop that should handle all network events,
+    /// action processing, and swarm management. The implementation should
+    /// run indefinitely until an error occurs or shutdown is requested.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SwarmError`] if a critical network error occurs that
+    /// prevents continued operation.
     async fn run(self) -> Result<(), SwarmError>;
 }

--- a/crates/network/src/utils.rs
+++ b/crates/network/src/utils.rs
@@ -1,7 +1,10 @@
+//! Utility functions.
+
 use std::net::SocketAddr;
 
 use libp2p::multiaddr;
 
+/// Converts a `SocketAddr` to a libp2p `MultiAddr`.
 pub fn multiaddr_from_socketaddr(
     addr: SocketAddr,
 ) -> Result<multiaddr::Multiaddr, multiaddr::Error> {

--- a/crates/scheduler/src/main.rs
+++ b/crates/scheduler/src/main.rs
@@ -1,3 +1,5 @@
+//! Scheduler binary.
+
 mod network;
 mod tasks;
 

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -1,3 +1,8 @@
+//! Networking utilities for the scheduler component.
+//!
+//! The scheduler orchestrates workers via libp2p. This module brings together
+//! the networking primitives and drives the underlying swarm.
+
 use std::collections::HashMap;
 
 use futures_util::stream::StreamExt;

--- a/crates/worker/src/main.rs
+++ b/crates/worker/src/main.rs
@@ -1,3 +1,5 @@
+//! Worker binary.
+
 mod driver;
 mod file_transfer;
 mod network;

--- a/crates/worker/src/network.rs
+++ b/crates/worker/src/network.rs
@@ -1,3 +1,9 @@
+//! Networking utilities for the worker component.
+//!
+//! Workers use this module to communicate with the scheduler and other peers.
+//! It ties together the networking primitives and drives the swarm. This
+//! documentation follows the [rustdoc guidelines](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+
 use std::collections::HashMap;
 
 use futures_util::stream::StreamExt;


### PR DESCRIPTION
Added a new “Documentation” section to the contributing guidelines requiring front-page crate docs and docs on all public items. Added crate‐ and module‐level docs across the gateway, network, scheduler, and worker to following the guidelines.