### PR TITLE
Configurable listen address

### DIFF
--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -9,6 +9,7 @@ pub mod mtls;
 pub mod request_response;
 pub mod stream;
 pub mod swarm;
+pub mod utils;
 
 // Re-export commonly used certificate types
 pub use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};

--- a/crates/network/src/utils.rs
+++ b/crates/network/src/utils.rs
@@ -1,0 +1,32 @@
+use std::net::SocketAddr;
+
+use libp2p::multiaddr;
+
+pub fn multiaddr_from_socketaddr(
+    addr: SocketAddr,
+) -> Result<multiaddr::Multiaddr, multiaddr::Error> {
+    if addr.is_ipv6() {
+        format!("/ip6/{}/tcp/{}", addr.ip(), addr.port()).parse()
+    } else {
+        format!("/ip4/{}/tcp/{}", addr.ip(), addr.port()).parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multiaddr_from_socketaddr_ipv4() {
+        let addr = "127.0.0.1:8080".parse().unwrap();
+        let multiaddr = multiaddr_from_socketaddr(addr).unwrap();
+        assert_eq!(multiaddr.to_string(), "/ip4/127.0.0.1/tcp/8080");
+    }
+
+    #[test]
+    fn test_multiaddr_from_socketaddr_ipv6() {
+        let addr = "[::1]:8080".parse().unwrap();
+        let multiaddr = multiaddr_from_socketaddr(addr).unwrap();
+        assert_eq!(multiaddr.to_string(), "/ip6/::1/tcp/8080");
+    }
+}


### PR DESCRIPTION
Make the listen address of all Hypha components configurable to allow for more deployments scenarios. E.g., to bind to specific network devices, choose between IPv4 or IPv6, ...

Futhermore, this uses `SocketAddr` ("{ip}:{port}") instead of `Multiaddr`. This is done to reduce possible configuration errors possbile with `Multiaddr`.