### PR TITLE
Prototype task communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,7 +1343,9 @@ dependencies = [
 name = "hypha-api"
 version = "0.0.0"
 dependencies = [
+ "libp2p",
  "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -1367,6 +1406,7 @@ dependencies = [
 name = "hypha-scheduler"
 version = "0.1.0"
 dependencies = [
+ "ciborium",
  "clap",
  "futures-util",
  "hypha-api",
@@ -1376,12 +1416,14 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
 name = "hypha-worker"
 version = "0.1.0"
 dependencies = [
+ "ciborium",
  "clap",
  "futures-util",
  "hypha-api",
@@ -3697,6 +3739,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2024"
 
 [workspace.dependencies]
 async-trait = "0.1.88"
+ciborium = "0.2.2"
 clap = { version = "4.5.31", features = ["derive"] }
 futures-rustls = { version = "0.26.0", default-features = false }
 futures-util = "0.3"
@@ -63,6 +64,7 @@ tokio = { version = "1.43.0", features = [
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
 webpki = { version = "0.103", package = "rustls-webpki", features = ["std"] }
 x509-parser = "0.16"
 

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -6,4 +6,6 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
+libp2p.workspace = true
 serde.workspace = true
+uuid.workspace = true

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -1,13 +1,101 @@
+use std::{error::Error, fmt, str::FromStr};
+
+use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Published by schedulers, requesting participating workers to signal
+/// their status and available resource to the scheduler.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RequestAnnounce {
+    pub task_id: Uuid,
+    pub scheduler_peer_id: PeerId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum TaskStatus {
+    Running,
+    Finished,
+    Failed,
+    Unknown,
+}
+
+#[derive(Debug)]
+pub struct StatusParseError(String);
+
+impl fmt::Display for StatusParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown task status '{}'", self.0)
+    }
+}
+
+impl Error for StatusParseError {}
+
+impl FromStr for TaskStatus {
+    type Err = StatusParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Running" => Ok(Self::Running),
+            "Finished" => Ok(Self::Finished),
+            "Failed" => Ok(Self::Failed),
+            "Unknown" => Ok(Self::Unknown),
+            other => Err(StatusParseError(other.to_string())),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum WorkerRole {
+    #[serde(rename = "task")]
+    TaskExecutor,
+    #[serde(rename = "parameter")]
+    ParameterExecutor,
+}
+
+/// Requests sent from workers to schedulers.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum WorkerRequest {
+    Available { task_id: Uuid, role: WorkerRole },
+    TaskStatus { task_id: Uuid, status: TaskStatus },
+}
+
+/// Responses to worker requests, sent from schedulers to workers.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum WorkerResponse {
+    Available {},
+    TaskStatus {},
+}
+
+/// Requests sent from schedulers to workers.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SchedulerRequest {
+    Work {
+        task_id: Uuid,
+        parameter_server_peer_id: PeerId,
+    },
+}
+
+/// Responses to scheduler requests, sent from workers to schedulers.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum SchedulerResponse {
+    Work {},
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
-    Work(String),
+    Worker(WorkerRequest),
+    Scheduler(SchedulerRequest),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Response {
-    WorkDone(),
-    Acknowledged(),
-    Error(String),
+    Worker(WorkerResponse),
+    Scheduler(SchedulerResponse),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ArtifactHeader {
+    pub task_id: Uuid,
+    pub epoch: u64,
 }

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
+ciborium.workspace = true
 clap.workspace = true
 futures-util.workspace = true
 hypha-api.workspace = true
@@ -15,3 +16,4 @@ libp2p-stream.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true

--- a/crates/scheduler/src/main.rs
+++ b/crates/scheduler/src/main.rs
@@ -1,18 +1,29 @@
 mod network;
+mod tasks;
 
-use std::{error::Error, fs, net::SocketAddr, path::PathBuf, time::Duration};
+use std::{error::Error, fs, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use clap::Parser;
 use hypha_network::{
-    cert::{load_certs_from_pem, load_crls_from_pem, load_private_key_from_pem},
+    cert::{
+        identity_from_private_key, load_certs_from_pem, load_crls_from_pem,
+        load_private_key_from_pem,
+    },
     dial::DialInterface,
+    gossipsub::GossipsubInterface,
     listen::ListenInterface,
+    request_response::{RequestResponseInterface, RequestResponseInterfaceExt},
     swarm::SwarmDriver,
     utils::multiaddr_from_socketaddr,
 };
+use libp2p::PeerId;
+use tokio::{sync::Mutex, task::JoinSet};
 use tracing_subscriber::EnvFilter;
 
-use crate::network::Network;
+use crate::{
+    network::Network,
+    tasks::{TaskId, Tasks},
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -62,6 +73,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         vec![]
     };
 
+    let local_peer_id = identity_from_private_key(&private_key)?
+        .public()
+        .to_peer_id();
     let gateway_address = multiaddr_from_socketaddr(opt.gateway_address)?;
 
     let (network, network_driver) = Network::create(cert_chain, private_key, ca_certs, crls)?;
@@ -80,5 +94,125 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // TODO: Provide a way to wait for this event
     tokio::time::sleep(Duration::from_secs(2)).await;
 
+    let scheduler = Arc::new(Mutex::new(Tasks::new()));
+
+    let handler = network
+        .on(|req: &hypha_api::Request| matches!(req, hypha_api::Request::Worker(_)))
+        .into_stream()
+        .await?;
+
+    let handler_future = {
+        let network = network.clone();
+        let scheduler = scheduler.clone();
+
+        handler.respond_with_concurrent(None, move |(peer_id, req)| {
+            let network = network.clone();
+            let scheduler = scheduler.clone();
+            async move {
+                match req {
+                    hypha_api::Request::Worker(worker) => match worker {
+                        hypha_api::WorkerRequest::Available { task_id, role } => {
+                            tracing::debug!(
+                                task_id = %task_id,
+                                peer_id = %peer_id,
+                                "Received available worker request",
+                            );
+                            let (participants, parameter_server_peer_id) = if let Some(task) =
+                                scheduler.lock().await.get_task(&task_id)
+                            {
+                                match role {
+                                    hypha_api::WorkerRole::TaskExecutor => task.add_worker(peer_id),
+                                    hypha_api::WorkerRole::ParameterExecutor => {
+                                        task.add_parameter_server(peer_id)
+                                    }
+                                };
+                                (
+                                    task.workers().cloned().collect::<Vec<_>>(),
+                                    task.parameter_server(),
+                                )
+                            } else {
+                                (Vec::new(), None)
+                            };
+
+                            // TODO: This is very simple and hard-coded scheduling:
+                            // Once 2 workers and a parameter server have connected, we start a task.
+                            // The criteria when and with whom to start a task need to be added later.
+                            if participants.len() == 2 {
+                                if let Some(parameter_server_peer_id) = parameter_server_peer_id {
+                                    tokio::spawn(run_task(
+                                        network.clone(),
+                                        task_id,
+                                        parameter_server_peer_id,
+                                        participants,
+                                    ));
+                                }
+                            }
+
+                            hypha_api::Response::Worker(hypha_api::WorkerResponse::Available {})
+                        }
+                        hypha_api::WorkerRequest::TaskStatus { task_id, status } => {
+                            if let Some(task) = scheduler.lock().await.get_task(&task_id) {
+                                task.update_status(&peer_id, status);
+                            }
+
+                            hypha_api::Response::Worker(hypha_api::WorkerResponse::TaskStatus {})
+                        }
+                    },
+                    _ => {
+                        panic!("Unexpected request received");
+                    }
+                }
+            }
+        })
+    };
+
+    tracing::debug!("Publishing task announcement");
+
+    let task_id = scheduler.lock().await.create_task();
+
+    let mut data = Vec::new();
+
+    ciborium::into_writer(
+        &hypha_api::RequestAnnounce {
+            task_id,
+            scheduler_peer_id: local_peer_id,
+        },
+        &mut data,
+    )
+    .unwrap();
+
+    let _ = network.publish("announce", data).await;
+
+    handler_future.await;
+
     Ok(())
+}
+
+async fn run_task(
+    network: Network,
+    task_id: TaskId,
+    parameter_server_peer_id: PeerId,
+    worker_peer_ids: Vec<PeerId>,
+) {
+    let mut set = JoinSet::new();
+
+    for worker_peer_id in worker_peer_ids {
+        tracing::debug!(task_id = %task_id, peer_id = %worker_peer_id, "Requesting work");
+        let network = network.clone();
+        set.spawn(async move {
+            network
+                .request(
+                    worker_peer_id,
+                    hypha_api::Request::Scheduler(hypha_api::SchedulerRequest::Work {
+                        task_id,
+                        parameter_server_peer_id,
+                    }),
+                )
+                .await
+        });
+    }
+
+    let _result = set.join_all().await;
+
+    tracing::debug!(task_id = %task_id, "Work done");
 }

--- a/crates/scheduler/src/tasks.rs
+++ b/crates/scheduler/src/tasks.rs
@@ -1,0 +1,75 @@
+use std::collections::{HashMap, HashSet};
+
+use libp2p::PeerId;
+use uuid::Uuid;
+
+pub(crate) type TaskId = Uuid;
+
+/// A very simple class to keep track of DiLoCo-like tasks
+/// and the participating workers and parameter servers.
+pub(crate) struct Tasks {
+    tasks: HashMap<TaskId, Task>,
+}
+
+impl Tasks {
+    pub fn new() -> Self {
+        Self {
+            tasks: HashMap::new(),
+        }
+    }
+
+    pub fn create_task(&mut self) -> TaskId {
+        let task_id = Uuid::new_v4();
+        let task = Task {
+            workers: HashMap::new(),
+            parameter_servers: HashSet::new(),
+        };
+
+        self.tasks.insert(task_id, task);
+
+        task_id
+    }
+
+    pub fn get_task(&mut self, task_id: &TaskId) -> Option<&mut Task> {
+        self.tasks.get_mut(task_id)
+    }
+}
+
+pub(crate) struct Task {
+    workers: HashMap<PeerId, hypha_api::TaskStatus>,
+    parameter_servers: HashSet<PeerId>,
+}
+
+impl Task {
+    pub fn add_worker(&mut self, participant: PeerId) {
+        self.workers
+            .insert(participant, hypha_api::TaskStatus::Unknown);
+    }
+
+    pub fn add_parameter_server(&mut self, participant: PeerId) {
+        self.parameter_servers.insert(participant);
+    }
+
+    pub fn workers(&self) -> impl Iterator<Item = &PeerId> {
+        self.workers.keys()
+    }
+
+    // HACK! right now we assume a single parameter server.
+    // We need to support multiple though.
+    pub fn parameter_server(&self) -> Option<PeerId> {
+        self.parameter_servers.iter().next().cloned()
+    }
+
+    pub fn update_status(
+        &mut self,
+        participant: &PeerId,
+        status: hypha_api::TaskStatus,
+    ) -> Option<()> {
+        if let Some(current_status) = self.workers.get_mut(participant) {
+            *current_status = status;
+            Some(())
+        } else {
+            None
+        }
+    }
+}

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
+ciborium.workspace = true
 clap.workspace = true
 futures-util.workspace = true
 hypha-api.workspace = true


### PR DESCRIPTION
Schedulers announce tasks to workers. Available workers respond and once enough workers have responded, the task will be distributed among the participating workers. The necessary messages and application logic is implemented here as a prototype. Additional information needs to be added to the messages (e.g. available resources) and the scheduler logic needs to be configurable, it's hard-coded currently.

Actual task handling on the workers will be added later.