### PR TITLE
Fix clippy warnings

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
 disallowed-methods = [
     { path = "futures::channel::mpsc::unbounded", reason = "does not enforce backpressure" },
-    { path = "tokio::sync::mpsc::unbounded", reason = "does not enforce backpressure" },
+    { path = "tokio::sync::mpsc::unbounded_channel", reason = "does not enforce backpressure" },
 ]
 avoid-breaking-exported-api = false

--- a/crates/gateway/src/network.rs
+++ b/crates/gateway/src/network.rs
@@ -65,11 +65,11 @@ impl Network {
 
         // Create a libp2p keypair from the certificate and private key
         let identity = cert::identity_from_private_key(&private_key)
-            .map_err(|e| HyphaError::SwarmError(format!("Failed to create identity: {}", e)))?;
+            .map_err(|e| HyphaError::SwarmError(format!("Failed to create identity: {e}")))?;
 
         // Create mTLS config
         let mtls_config = mtls::Config::try_new(cert_chain, private_key, ca_certs, crls)
-            .map_err(|e| HyphaError::SwarmError(format!("Failed to create mTLS config: {}", e)))?;
+            .map_err(|e| HyphaError::SwarmError(format!("Failed to create mTLS config: {e}")))?;
 
         let mut swarm = SwarmBuilder::with_existing_identity(identity)
             .with_tokio()

--- a/crates/network/examples/request_response/main.rs
+++ b/crates/network/examples/request_response/main.rs
@@ -88,7 +88,7 @@ async fn server(args: Args, listen_addr: &str) -> Result<(), Box<dyn Error>> {
                 match req {
                     ExampleRequest::Ping(msg) => {
                         tracing::info!("Received ping: {}", msg);
-                        ExampleResponse::Pong(format!("Pong: {}", msg))
+                        ExampleResponse::Pong(format!("Pong: {msg}"))
                     }
                     ExampleRequest::Echo(msg) => {
                         tracing::info!("Received echo: {}", msg);
@@ -163,10 +163,10 @@ async fn create_network(args: Args) -> Result<(Network, NetworkDriver), Box<dyn 
     };
 
     let identity = hypha_network::cert::identity_from_private_key(&private_key)
-        .map_err(|e| format!("Failed to create identity: {}", e))?;
+        .map_err(|e| format!("Failed to create identity: {e}"))?;
 
     let mtls_config = mtls::Config::try_new(cert_chain, private_key, ca_certs, crls)
-        .map_err(|e| format!("Failed to create mTLS config: {}", e))?;
+        .map_err(|e| format!("Failed to create mTLS config: {e}"))?;
 
     let swarm = SwarmBuilder::with_existing_identity(identity)
         .with_tokio()

--- a/crates/network/src/cert.rs
+++ b/crates/network/src/cert.rs
@@ -261,7 +261,7 @@ mod tests {
         let (cert1_pem, _, _) = generate_ed25519_cert();
         let (cert2_pem, _, _) = generate_ed25519_cert();
 
-        let combined_pem = format!("{}\n{}", cert1_pem, cert2_pem);
+        let combined_pem = format!("{cert1_pem}\n{cert2_pem}");
         let certs = load_certs_from_pem(combined_pem.as_bytes()).unwrap();
         assert_eq!(certs.len(), 2);
     }

--- a/crates/network/src/error.rs
+++ b/crates/network/src/error.rs
@@ -15,8 +15,8 @@ impl Error for HyphaError {
 impl Display for HyphaError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DialError(msg) => write!(f, "Dial error: {}", msg),
-            Self::SwarmError(msg) => write!(f, "Swarm error: {}", msg),
+            Self::DialError(msg) => write!(f, "Dial error: {msg}"),
+            Self::SwarmError(msg) => write!(f, "Swarm error: {msg}"),
         }
     }
 }

--- a/crates/network/src/kad.rs
+++ b/crates/network/src/kad.rs
@@ -60,12 +60,12 @@ impl Error for KademliaError {
 impl Display for KademliaError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::GetProviders(msg) => write!(f, "Get Providers error: {}", msg),
-            Self::GetRecord(msg) => write!(f, "Get Record error: {}", msg),
-            Self::Store(msg) => write!(f, "Store error: {}", msg),
-            Self::PutRecord(msg) => write!(f, "Put Record error: {}", msg),
-            Self::GetClosestPeers(msg) => write!(f, "Get Closest Peers error: {}", msg),
-            Self::Other(msg) => write!(f, "Other error: {}", msg),
+            Self::GetProviders(msg) => write!(f, "Get Providers error: {msg}"),
+            Self::GetRecord(msg) => write!(f, "Get Record error: {msg}"),
+            Self::Store(msg) => write!(f, "Store error: {msg}"),
+            Self::PutRecord(msg) => write!(f, "Put Record error: {msg}"),
+            Self::GetClosestPeers(msg) => write!(f, "Get Closest Peers error: {msg}"),
+            Self::Other(msg) => write!(f, "Other error: {msg}"),
         }
     }
 }

--- a/crates/network/src/listen.rs
+++ b/crates/network/src/listen.rs
@@ -66,8 +66,7 @@ pub trait ListenInterface: Sync {
 
             rx.await.map_err(|err| {
                 TransportError::Other(IoError::other(format!(
-                    "Failed to recieve action response: {}",
-                    err
+                    "Failed to recieve action response: {err}"
                 )))
             })?
         }

--- a/crates/network/src/mtls.rs
+++ b/crates/network/src/mtls.rs
@@ -126,7 +126,7 @@ impl Config {
         let mut root_store = RootCertStore::empty();
         for ca_cert in &ca_certs {
             root_store.add(ca_cert.clone()).map_err(|e| {
-                UpgradeError::TlsConfiguration(format!("Failed to add CA cert: {}", e))
+                UpgradeError::TlsConfiguration(format!("Failed to add CA cert: {e}"))
             })?;
         }
 
@@ -135,15 +135,13 @@ impl Config {
             .with_crls(crls)
             .build()
             .map_err(|e| {
-                UpgradeError::TlsConfiguration(format!("Failed to create client verifier: {}", e))
+                UpgradeError::TlsConfiguration(format!("Failed to create client verifier: {e}"))
             })?;
 
         ServerConfig::builder()
             .with_client_cert_verifier(client_verifier)
             .with_single_cert(cert_chain, private_key)
-            .map_err(|e| {
-                UpgradeError::TlsConfiguration(format!("Failed to configure server: {}", e))
-            })
+            .map_err(|e| UpgradeError::TlsConfiguration(format!("Failed to configure server: {e}")))
     }
 
     fn make_client_config(
@@ -156,7 +154,7 @@ impl Config {
         let mut root_store = RootCertStore::empty();
         for ca_cert in &ca_certs {
             root_store.add(ca_cert.clone()).map_err(|e| {
-                UpgradeError::TlsConfiguration(format!("Failed to add CA cert: {}", e))
+                UpgradeError::TlsConfiguration(format!("Failed to add CA cert: {e}"))
             })?;
         }
 
@@ -168,9 +166,7 @@ impl Config {
         ClientConfig::builder()
             .with_root_certificates(root_store)
             .with_client_auth_cert(cert_chain, private_key)
-            .map_err(|e| {
-                UpgradeError::TlsConfiguration(format!("Failed to configure client: {}", e))
-            })
+            .map_err(|e| UpgradeError::TlsConfiguration(format!("Failed to configure client: {e}")))
     }
 }
 
@@ -272,10 +268,7 @@ fn extract_peer_id_from_tls_state(state: &CommonState) -> Result<PeerId, Upgrade
     // 1. Parse the certificate using rustls-webpki
     // rustls_webpki::EndEntityCert::try_from takes &[u8]
     let end_entity_cert = EndEntityCert::try_from(cert_der).map_err(|e| {
-        UpgradeError::TlsConfiguration(format!(
-            "Failed to parse peer certificate with webpki: {}",
-            e
-        ))
+        UpgradeError::TlsConfiguration(format!("Failed to parse peer certificate with webpki: {e}"))
     })?;
 
     // 2. Get the SubjectPublicKeyInfo (SPKI) DER bytes

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -83,11 +83,11 @@ impl Network {
 
         // Create a libp2p identity keypair from provided private key.
         let identity = cert::identity_from_private_key(&private_key)
-            .map_err(|e| HyphaError::SwarmError(format!("Failed to create identity: {}", e)))?;
+            .map_err(|e| HyphaError::SwarmError(format!("Failed to create identity: {e}")))?;
 
         // Create mTLS config
         let mtls_config = mtls::Config::try_new(cert_chain, private_key, ca_certs, crls)
-            .map_err(|e| HyphaError::SwarmError(format!("Failed to create mTLS config: {}", e)))?;
+            .map_err(|e| HyphaError::SwarmError(format!("Failed to create mTLS config: {e}")))?;
 
         // Build libp2p Swarm using the derived identity and mTLS config
         let swarm = SwarmBuilder::with_existing_identity(identity)

--- a/crates/worker/src/network.rs
+++ b/crates/worker/src/network.rs
@@ -80,11 +80,11 @@ impl Network {
 
         // Create a libp2p keypair from the certificate and private key
         let identity = cert::identity_from_private_key(&private_key)
-            .map_err(|e| HyphaError::SwarmError(format!("Failed to create identity: {}", e)))?;
+            .map_err(|e| HyphaError::SwarmError(format!("Failed to create identity: {e}")))?;
 
         // Create mTLS config (crypto provider is initialized in mtls::Config::new)
         let mtls_config = mtls::Config::try_new(cert_chain, private_key, ca_certs, crls)
-            .map_err(|e| HyphaError::SwarmError(format!("Failed to create mTLS config: {}", e)))?;
+            .map_err(|e| HyphaError::SwarmError(format!("Failed to create mTLS config: {e}")))?;
 
         let swarm = SwarmBuilder::with_existing_identity(identity)
             .with_tokio()


### PR DESCRIPTION
With Rust 1.88 the `uninlined_format_args` lint was moved from `pedantic` to `style` which caused a lot of warnings in our code. This has been fixed.

Clippy 1.88 changelog: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-188