### PR TITLE
style: collapse ifs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1147,9 +1147,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1664,7 +1664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -2321,7 +2321,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/crates/network/src/request_response.rs
+++ b/crates/network/src/request_response.rs
@@ -746,10 +746,10 @@ where
                         "Outbound request-response failure"
                     );
 
-                    if let Some(tx) = self.outbound_requests().remove(&request_id) {
-                        if tx.send(Err(RequestResponseError::Request(error))).is_err() {
-                            tracing::debug!("Failed to send error to request handler");
-                        }
+                    if let Some(tx) = self.outbound_requests().remove(&request_id)
+                        && tx.send(Err(RequestResponseError::Request(error))).is_err()
+                    {
+                        tracing::debug!("Failed to send error to request handler");
                     }
                 }
                 Event::ResponseSent {
@@ -761,10 +761,10 @@ where
                         "Response sent successfully"
                     );
 
-                    if let Some(tx) = self.outbound_responses().remove(&request_id) {
-                        if tx.send(Ok(())).is_err() {
-                            tracing::debug!("Response confirmation receiver dropped");
-                        }
+                    if let Some(tx) = self.outbound_responses().remove(&request_id)
+                        && tx.send(Ok(())).is_err()
+                    {
+                        tracing::debug!("Response confirmation receiver dropped");
                     }
                 }
             }

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -139,15 +139,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             // TODO: This is very simple and hard-coded scheduling:
                             // Once 2 workers and a parameter server have connected, we start a task.
                             // The criteria when and with whom to start a task need to be added later.
-                            if participants.len() == 2 {
-                                if let Some(parameter_server_peer_id) = parameter_server_peer_id {
-                                    tokio::spawn(start_task(
-                                        network.clone(),
-                                        task_id,
-                                        parameter_server_peer_id,
-                                        participants,
-                                    ));
-                                }
+                            if participants.len() == 2
+                                && let Some(parameter_server_peer_id) = parameter_server_peer_id
+                            {
+                                tokio::spawn(start_task(
+                                    network.clone(),
+                                    task_id,
+                                    parameter_server_peer_id,
+                                    participants,
+                                ));
                             }
 
                             hypha_messages::Response::Worker(


### PR DESCRIPTION
With Rust 1.89, 'cargo clippy' complains about more nested ifs. These have been collapsed.