### PR TITLE
feat(network): multi-codec req/resp + health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "figment",
  "futures-util",
  "hypha-config",
+ "hypha-messages",
  "hypha-network",
  "libp2p",
  "miette",
@@ -1924,6 +1925,7 @@ dependencies = [
 name = "hypha-messages"
 version = "0.0.0"
 dependencies = [
+ "hypha-network",
  "libp2p",
  "serde",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libp2p = { version = "0.56.0", features = [
     "tls",
     "tokio",
     "yamux",
-] }
+    ] }
 libp2p-stream = { version = "0.4.0-alpha" }
 libp2p-swarm-test = { version = "0.6.0", features = ["tokio"] }
 miette = { version = "7.6.0", features = ["fancy"] }

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -12,6 +12,7 @@ figment.workspace = true
 futures-util.workspace = true
 hypha-config.workspace = true
 hypha-network.workspace = true
+hypha-messages.workspace = true
 libp2p.workspace = true
 miette.workspace = true
 serde.workspace = true

--- a/crates/gateway/src/bin/hypha-gateway.rs
+++ b/crates/gateway/src/bin/hypha-gateway.rs
@@ -1,12 +1,22 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use clap::{Parser, Subcommand};
 use figment::providers::{Env, Format, Serialized, Toml};
 use futures_util::future::join_all;
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_gateway::{config::Config, network::Network};
+use hypha_messages::health;
 use hypha_network::{
-    external_address::ExternalAddressInterface, listen::ListenInterface, swarm::SwarmDriver,
+    dial::DialInterface, external_address::ExternalAddressInterface, listen::ListenInterface,
+    request_response::RequestResponseInterfaceExt, swarm::SwarmDriver,
 };
 use libp2p::Multiaddr;
 use miette::{IntoDiagnostic, Result};
@@ -34,16 +44,73 @@ enum Commands {
         #[clap(short, long, default_value = "config.toml")]
         output: PathBuf,
     },
+    /// Probe a target multiaddr for readiness and exit 0 if healthy.
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
+        /// Timeout in milliseconds
+        #[clap(long, default_value_t = 2000)]
+        timeout: u64,
+
+        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
+        #[clap(index = 1)]
+        address: String,
+    },
     #[serde(untagged)]
     Run {
         /// Path to the configuration file.
         #[clap(short, long("config"), default_value = "config.toml")]
         #[serde(skip)]
         config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
         /// Addresses to listen on (can be specified multiple times).
         #[clap(long("listen"))]
         #[serde(skip_serializing_if = "Option::is_none")]
         listen_addresses: Option<Vec<Multiaddr>>,
+
         /// External addresses to advertise (can be specified multiple times).
         #[clap(long("external"))]
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -52,6 +119,9 @@ enum Commands {
 }
 
 async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
+    // NOTE: Ready when listening on all addresses.
+    let ready = Arc::new(AtomicBool::new(false));
+
     let cert_chain = config.load_cert_chain()?;
     let private_key = config.load_key()?;
     let ca_certs = config.load_trust_chain()?;
@@ -60,6 +130,21 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     let (network, network_driver) =
         Network::create(cert_chain, private_key, ca_certs, crls).into_diagnostic()?;
     let driver_future = tokio::spawn(network_driver.run());
+
+    // Register health handler responding with readiness
+    let ready_clone = ready.clone();
+    let health_handle = network
+        .on::<health::Codec, _>(|_: &health::Request| true)
+        .into_stream()
+        .await
+        .into_diagnostic()?
+        .respond_with_concurrent(None, move |(_, _)| {
+            let ready = ready_clone.clone();
+            async move {
+                let flag = ready.load(Ordering::Relaxed);
+                health::Response { healthy: flag }
+            }
+        });
 
     // NOTE: This will not complete until we're listening on all addresses.
     join_all(
@@ -73,6 +158,9 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     .into_iter()
     .collect::<Result<Vec<_>, _>>()
     .into_diagnostic()?;
+
+    // NOTE: Mark gateway as healthy once all listens are active (per requirement).
+    ready.store(true, Ordering::Relaxed);
 
     // NOTE: This will not complete until all external addresses are added.
     join_all(
@@ -92,6 +180,9 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         }
         _ = sigterm.recv() => {
             tracing::info!("Received SIGTERM, shutting down");
+        }
+        _ = health_handle => {
+            tracing::info!("Health handler terminated, shutting down");
         }
         _ = driver_future => {
             tracing::warn!("Network driver terminated, shutting down");
@@ -115,11 +206,52 @@ async fn main() -> Result<()> {
             println!("Configuration written to: {output:?}");
             Ok(())
         }
+        args @ Commands::Probe {
+            config_file,
+            address,
+            timeout,
+            ..
+        } => {
+            let config = builder::<Config>()
+                .with_provider(Toml::file(config_file))
+                .with_provider(Env::prefixed("HYPHA_"))
+                .with_provider(Serialized::defaults(&args))
+                .build()?;
+
+            let (network, driver) = Network::create(
+                config.load_cert_chain()?,
+                config.load_key()?,
+                config.load_trust_chain()?,
+                config.load_crls()?,
+            )
+            .into_diagnostic()?;
+            tokio::spawn(driver.run());
+
+            let addr: Multiaddr = address.parse().into_diagnostic()?;
+            tokio::time::timeout(Duration::from_millis(*timeout), async move {
+                let peer = network.dial(addr).await.into_diagnostic()?;
+
+                let resp = network
+                    .request::<health::Codec>(peer, health::Request {})
+                    .await
+                    .into_diagnostic()?;
+
+                if resp.healthy {
+                    Ok(())
+                } else {
+                    Err(miette::miette!("unhealthy"))
+                }
+            })
+            .await
+            .into_diagnostic()??;
+
+            Ok(())
+        }
         args @ Commands::Run { config_file, .. } => {
             let config = builder::<Config>()
                 .with_provider(Toml::file(config_file))
-                .with_provider(Env::prefixed("HYPHA_GATEWAY_"))
-                .with_provider(Serialized::defaults(args))
+                .with_provider(Env::prefixed("HYPHA_"))
+                .with_provider(Serialized::defaults(&args))
                 .build()?;
 
             return run(config).await;

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -9,3 +9,4 @@ license = "Apache-2.0"
 libp2p.workspace = true
 serde.workspace = true
 uuid.workspace = true
+hypha-network.workspace = true

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt, str::FromStr, time::SystemTime};
 
-use libp2p::PeerId;
+use libp2p::{PeerId, request_response::cbor::codec::Codec as CborCodec};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -11,25 +11,52 @@ pub struct ArtifactHeader {
     pub epoch: u64,
 }
 
-#[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Request {
-    WorkerOffer(worker_offer::Request),
-    RenewLease(renew_lease::Request),
-    JobStatus(job_status::Request),
-    DispatchJob(dispatch_job::Request),
-    ParameterPull(parameter_pull::Request),
-    ParameterPush(parameter_push::Request),
+pub mod api {
+    use super::*;
+
+    pub type Codec = CborCodec<Request, Response>;
+
+    pub const IDENTIFIER: &str = "/hypha-api/0.0.1";
+
+    #[allow(clippy::large_enum_variant)]
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub enum Request {
+        WorkerOffer(worker_offer::Request),
+        RenewLease(renew_lease::Request),
+        JobStatus(job_status::Request),
+        DispatchJob(dispatch_job::Request),
+        ParameterPull(parameter_pull::Request),
+        ParameterPush(parameter_push::Request),
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub enum Response {
+        WorkerOffer(worker_offer::Response),
+        RenewLease(renew_lease::Response),
+        JobStatus(job_status::Response),
+        DispatchJob(dispatch_job::Response),
+        ParameterPull(parameter_pull::Response),
+        ParameterPush(parameter_push::Response),
+    }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Response {
-    WorkerOffer(worker_offer::Response),
-    RenewLease(renew_lease::Response),
-    JobStatus(job_status::Response),
-    DispatchJob(dispatch_job::Response),
-    ParameterPull(parameter_pull::Response),
-    ParameterPush(parameter_push::Response),
+/// Health request/response messages
+pub mod health {
+    use core::str;
+
+    use super::*;
+
+    pub type Codec = CborCodec<Request, Response>;
+
+    pub static IDENTIFIER: &str = "/hypha-health/0.0.1";
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Request {}
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Response {
+        pub healthy: bool,
+    }
 }
 
 // Protocol: Scheduler requests available workers

--- a/crates/network/examples/request_response/main.rs
+++ b/crates/network/examples/request_response/main.rs
@@ -9,7 +9,7 @@ use hypha_network::{
     request_response::{
         OutboundRequests, OutboundResponses, RequestHandler, RequestResponseAction,
         RequestResponseBehaviour, RequestResponseDriver, RequestResponseError,
-        RequestResponseInterface, RequestResponseInterfaceExt,
+        RequestResponseInterfaceExt,
     },
     swarm::{SwarmDriver, SwarmError},
 };
@@ -308,7 +308,7 @@ impl Network {
     }
 }
 
-impl RequestResponseInterface<ExampleCodec> for Network {
+impl hypha_network::request_response::RequestResponseInterface<ExampleCodec> for Network {
     async fn send(&self, action: RequestResponseAction<ExampleCodec>) {
         let _ = self.action_tx.send(Action::RequestResponse(action)).await;
     }

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -6,6 +6,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
+use hypha_messages::{api, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
@@ -28,15 +29,15 @@ use hypha_network::{
 };
 use libp2p::{
     PeerId, StreamProtocol, Swarm, SwarmBuilder, dcutr, gossipsub, identify, kad, ping, relay,
-    request_response::{self, cbor::codec::Codec},
+    request_response,
     swarm::{ConnectionId, DialError, NetworkBehaviour, SwarmEvent},
     tcp, tls, yamux,
 };
 use libp2p_stream as stream;
 use tokio::sync::{SetOnce, mpsc, oneshot};
 
-pub type HyphaCodec = Codec<hypha_messages::Request, hypha_messages::Response>;
-type HyphaRequestHandlers = Vec<RequestHandler<HyphaCodec>>;
+type HyphaRequestHandlers = Vec<RequestHandler<api::Codec>>;
+type HealthRequestHandlers = Vec<RequestHandler<health::Codec>>;
 
 #[derive(Clone)]
 pub struct Network {
@@ -53,7 +54,8 @@ pub struct Behaviour {
     stream: stream::Behaviour,
     kademlia: kad::Behaviour<kad::store::MemoryStore>,
     gossipsub: gossipsub::Behaviour,
-    request_response: request_response::Behaviour<HyphaCodec>,
+    request_response: request_response::Behaviour<api::Codec>,
+    health_request_response: request_response::Behaviour<health::Codec>,
 }
 
 pub struct NetworkDriver {
@@ -64,9 +66,12 @@ pub struct NetworkDriver {
     pending_bootstrap: Arc<SetOnce<()>>,
     subscriptions: Subscriptions,
     action_receiver: mpsc::Receiver<Action>,
-    outbound_requests_map: OutboundRequests<HyphaCodec>,
+    outbound_requests_map: OutboundRequests<api::Codec>,
     outbound_responses_map: OutboundResponses,
     request_handlers: HyphaRequestHandlers,
+    health_outbound_requests_map: OutboundRequests<health::Codec>,
+    health_outbound_responses_map: OutboundResponses,
+    health_request_handlers: HealthRequestHandlers,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -75,7 +80,8 @@ enum Action {
     Listen(ListenAction),
     Kademlia(KademliaAction),
     Gossipsub(GossipsubAction),
-    RequestResponse(RequestResponseAction<HyphaCodec>),
+    RequestResponse(RequestResponseAction<api::Codec>),
+    HealthRequestResponse(RequestResponseAction<health::Codec>),
     ExternalAddress(ExternalAddressAction),
 }
 
@@ -127,10 +133,17 @@ impl Network {
                         kad::store::MemoryStore::new(key.public().to_peer_id()),
                     ),
                     gossipsub,
-                    request_response: request_response::Behaviour::<HyphaCodec>::new(
+                    request_response: request_response::Behaviour::<api::Codec>::new(
                         [(
-                            StreamProtocol::new("/hypha-api/0.0.1"),
+                            StreamProtocol::new(api::IDENTIFIER),
                             request_response::ProtocolSupport::Full,
+                        )],
+                        request_response::Config::default(),
+                    ),
+                    health_request_response: request_response::Behaviour::<health::Codec>::new(
+                        [(
+                            StreamProtocol::new(health::IDENTIFIER),
+                            request_response::ProtocolSupport::Outbound,
                         )],
                         request_response::Config::default(),
                     ),
@@ -156,6 +169,9 @@ impl Network {
                 outbound_requests_map: HashMap::default(),
                 outbound_responses_map: HashMap::default(),
                 request_handlers: Vec::new(),
+                health_outbound_requests_map: HashMap::default(),
+                health_outbound_responses_map: HashMap::default(),
+                health_request_handlers: Vec::new(),
                 action_receiver,
             },
         ))
@@ -191,7 +207,10 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         self.process_gossipsub_event(event).await;
                         }
                         SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(event)) => {
-                            self.process_request_response_event(event).await;
+                            <NetworkDriver as RequestResponseDriver<Behaviour, api::Codec>>::process_request_response_event(&mut self, event).await;
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::HealthRequestResponse(event)) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_event(&mut self, event).await;
                         }
                         SwarmEvent::Behaviour(BehaviourEvent::Dcutr(event)) => {
                             tracing::debug!("dcutr event: {:?}", event);
@@ -217,7 +236,9 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                             self.process_gossipsub_action(action).await;
                         },
                         Action::RequestResponse(action) =>
-                            self.process_request_response_action(action).await,
+                            <NetworkDriver as RequestResponseDriver<Behaviour, api::Codec>>::process_request_response_action(&mut self, action).await,
+                        Action::HealthRequestResponse(action) =>
+                            <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::ExternalAddress(action) =>
                             self.process_external_address_action(action).await,
                     }
@@ -319,14 +340,14 @@ impl GossipsubInterface for Network {
     }
 }
 
-impl RequestResponseBehaviour<HyphaCodec> for Behaviour {
-    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<HyphaCodec> {
+impl RequestResponseBehaviour<api::Codec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<api::Codec> {
         &mut self.request_response
     }
 }
 
-impl RequestResponseDriver<Behaviour, HyphaCodec> for NetworkDriver {
-    fn outbound_requests(&mut self) -> &mut OutboundRequests<HyphaCodec> {
+impl RequestResponseDriver<Behaviour, api::Codec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<api::Codec> {
         &mut self.outbound_requests_map
     }
 
@@ -339,8 +360,8 @@ impl RequestResponseDriver<Behaviour, HyphaCodec> for NetworkDriver {
     }
 }
 
-impl RequestResponseInterface<HyphaCodec> for Network {
-    async fn send(&self, action: RequestResponseAction<HyphaCodec>) {
+impl RequestResponseInterface<api::Codec> for Network {
+    async fn send(&self, action: RequestResponseAction<api::Codec>) {
         self.action_sender
             .send(Action::RequestResponse(action))
             .await
@@ -349,10 +370,48 @@ impl RequestResponseInterface<HyphaCodec> for Network {
 
     fn try_send(
         &self,
-        action: RequestResponseAction<HyphaCodec>,
+        action: RequestResponseAction<api::Codec>,
     ) -> Result<(), RequestResponseError> {
         self.action_sender
             .try_send(Action::RequestResponse(action))
+            .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
+    }
+}
+
+impl RequestResponseBehaviour<health::Codec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<health::Codec> {
+        &mut self.health_request_response
+    }
+}
+
+impl RequestResponseDriver<Behaviour, health::Codec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<health::Codec> {
+        &mut self.health_outbound_requests_map
+    }
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses {
+        &mut self.health_outbound_responses_map
+    }
+
+    fn request_handlers(&mut self) -> &mut HealthRequestHandlers {
+        &mut self.health_request_handlers
+    }
+}
+
+impl RequestResponseInterface<health::Codec> for Network {
+    async fn send(&self, action: RequestResponseAction<health::Codec>) {
+        self.action_sender
+            .send(Action::HealthRequestResponse(action))
+            .await
+            .expect("network driver is running");
+    }
+
+    fn try_send(
+        &self,
+        action: RequestResponseAction<health::Codec>,
+    ) -> Result<(), RequestResponseError> {
+        self.action_sender
+            .try_send(Action::HealthRequestResponse(action))
             .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
     }
 }


### PR DESCRIPTION
This change generalizes our request/response plumbing to support multiple codecs and introduces a dedicated health codec (protocol). The network layer now exposes typed (codec) helpers to register handlers and make requests.

A new health codec (`/hypha-health/0.0.1`) reports health/readiness. Gateway and worker register lightweight handlers that answer health requests once they meet their readiness criteria. All binaries feauture a `probe` subcommand that dials a target, performs a health request, and exits non-zero on failure/timeout, making it suitable for startup and liveness checks.