### PR TITLE
Allocate multiple workers at once and reduce refresh interval

### DIFF
--- a/crates/scheduler/src/worker.rs
+++ b/crates/scheduler/src/worker.rs
@@ -103,10 +103,9 @@ impl Worker {
 
                             let duration = timeout
                                 .duration_since(SystemTime::now())
-                                .unwrap_or(Duration::from_millis(500))
-                                .min(Duration::from_millis(500));
+                                .unwrap_or(Duration::from_secs(6));
 
-                            let safe_duration = duration / 4;
+                            let safe_duration = duration / 3 * 2;
 
                             tracing::info!(
                                 duration = duration.as_millis(),

--- a/crates/worker/src/arbiter.rs
+++ b/crates/worker/src/arbiter.rs
@@ -27,7 +27,7 @@ const WINDOW_LIMIT: usize = 100;
 const WINDOW_WAIT: std::time::Duration = std::time::Duration::from_millis(200);
 const OFFER_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(500);
 const PRUNE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
-const LEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const LEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[derive(Debug, Error)]
 #[error("lease error")]


### PR DESCRIPTION
Change the scheduler to allocate multiple workers at once instead of looping through single allocations. This reduces duplicate network requests, removes delays, and issues with temporary reservations starving subsequent requests. Along with this change adjust and reduce the lease refresh to reduce network noise.