### PR TITLE
feat(diloco): simplify optimizer

### DIFF
--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -380,14 +380,14 @@ impl AsRef<Reference> for Receive {
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum DiLoCoConfig {
     CausalLm {
-        optimizer: Optimizer,
+        optimizer: Adam,
         epochs: i32,
         batch_size: i32,
         checkpointing: i32,
         scheduler: Option<Scheduler>,
     },
     VisionClassification {
-        optimizer: Optimizer,
+        optimizer: Adam,
         epochs: i32,
         batch_size: i32,
         checkpointing: i32,
@@ -396,7 +396,7 @@ pub enum DiLoCoConfig {
         batches_per_local_epoch: i32,
     },
     Torch {
-        optimizer: Optimizer,
+        optimizer: Adam,
         loss_fn: Loss,
         epochs: i32,
         batch_size: i32,
@@ -423,22 +423,23 @@ pub enum Executor {
     ParameterServer {
         updates: Receive,
         results: Send,
-        optimizer: Optimizer,
+        optimizer: Nesterov,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(tag = "type", rename_all = "kebab-case")]
-pub enum Optimizer {
-    Adam {
-        learning_rate: f64,
-        betas: Option<[f64; 2]>,
-        epsilon: Option<f64>,
-    },
-    Nesterov {
-        learning_rate: f64,
-        momentum: f64,
-    },
+#[serde(rename_all = "kebab-case")]
+pub struct Nesterov {
+    pub learning_rate: f64,
+    pub momentum: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct Adam {
+    pub learning_rate: f64,
+    pub betas: Option<[f64; 2]>,
+    pub epsilon: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -7,8 +7,8 @@ use figment::providers::{Env, Format, Serialized, Toml};
 use futures_util::future::join_all;
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_messages::{
-    DataRecord, DiLoCoConfig, Executor, Fetch, JobSpec, Optimizer, Receive, Requirement, Resources,
-    SelectionStrategy, Send, WorkerSpec, health,
+    Adam, DataRecord, DiLoCoConfig, Executor, Fetch, JobSpec, Nesterov, Receive, Requirement,
+    Resources, SelectionStrategy, Send, WorkerSpec, health,
 };
 use hypha_network::{
     IpNet, cert::identity_from_private_key, dial::DialInterface,
@@ -365,7 +365,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
                 executor: Executor::ParameterServer {
                     updates: Receive::peers(worker_ids.clone()),
                     results: Send::peers(worker_ids.clone(), SelectionStrategy::All),
-                    optimizer: Optimizer::Nesterov {
+                    optimizer: Nesterov {
                         learning_rate: 0.7,
                         momentum: 0.9,
                     },
@@ -426,7 +426,7 @@ fn get_executor_with_dataset(
         updates: Receive::peers(vec![parameter_server]),
         results: Send::peers(vec![parameter_server], SelectionStrategy::One),
         config: DiLoCoConfig::VisionClassification {
-            optimizer: Optimizer::Adam {
+            optimizer: Adam {
                 learning_rate: 1e-3,
                 betas: None,
                 epsilon: None,

--- a/crates/worker/src/executor/parameter_server.rs
+++ b/crates/worker/src/executor/parameter_server.rs
@@ -89,14 +89,6 @@ impl JobExecutor for ParameterServerExecutor {
             _ => return Err(Error::UnsupportedJobSpec()),
         };
 
-        let (learning_rate, momentum) = match optimizer {
-            hypha_messages::Optimizer::Nesterov {
-                learning_rate,
-                momentum,
-            } => (learning_rate, momentum),
-            _ => return Err(Error::UnsupportedOptimizer()),
-        };
-
         let connector = self.connector.clone();
 
         let task_tracker = TaskTracker::new();
@@ -225,7 +217,7 @@ impl JobExecutor for ParameterServerExecutor {
                         fs::rename(result_file_name.as_path(), final_tensor_file_name.as_path()).await.expect("tensor file can be renamed");
 
                         // Do outer optimization
-                        let gradient_file =  nesterov(final_tensor_file_name.clone(),  work_dir.clone(), &device, momentum, learning_rate).await.expect("nesterov");
+                        let gradient_file =  nesterov(final_tensor_file_name.clone(),  work_dir.clone(), &device, optimizer.momentum, optimizer.learning_rate).await.expect("nesterov");
 
                         // These need to be reset before sending out the result!
                         current_result_tensor_file_name = None;

--- a/drivers/hypha-accelerate-driver/src/training.py
+++ b/drivers/hypha-accelerate-driver/src/training.py
@@ -120,19 +120,15 @@ def get_training_loop(
     raise RuntimeError(f"Model type {config} not supported for training.")
 
 
-def get_optimizer(optimizer: dict[str, Any], parameters: Iterable[torch.Tensor]) -> Optimizer:
-    optimizer_type = optimizer["type"]
-    if optimizer_type == "adam":
-        lr = optimizer["learning_rate"]
-        if optimizer.get("betas") and optimizer.get("epsilon"):
-            return torch.optim.AdamW(parameters, lr=lr, betas=optimizer["betas"], eps=optimizer["epsilon"])
-        if optimizer.get("betas"):
-            return torch.optim.AdamW(parameters, lr=lr, betas=optimizer["betas"])
-        if optimizer.get("epsilon"):
-            return torch.optim.AdamW(parameters, lr=lr, eps=optimizer["epsilon"])
-        return torch.optim.AdamW(parameters, lr=lr)
-    else:
-        raise RuntimeError(f"Optimizer {optimizer_type} doesn\bt exist.")
+def get_adam(optimizer: dict[str, Any], parameters: Iterable[torch.Tensor]) -> Optimizer:
+    lr = optimizer["learning-rate"]
+    if optimizer.get("betas") and optimizer.get("epsilon"):
+        return torch.optim.AdamW(parameters, lr=lr, betas=optimizer["betas"], eps=optimizer["epsilon"])
+    if optimizer.get("betas"):
+        return torch.optim.AdamW(parameters, lr=lr, betas=optimizer["betas"])
+    if optimizer.get("epsilon"):
+        return torch.optim.AdamW(parameters, lr=lr, eps=optimizer["epsilon"])
+    return torch.optim.AdamW(parameters, lr=lr)
 
 
 def get_data_loader(
@@ -235,7 +231,7 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
         local_fetch_path = f"{work_dir}/{FETCH_PATH}"
         print(os.listdir(local_fetch_path))
         model = get_model(local_fetch_path, job_spec["config"]["type"])
-        optimizer = get_optimizer(
+        optimizer = get_adam(
             job_spec["config"]["optimizer"],
             model.parameters(),
         )


### PR DESCRIPTION
DiLoCo runs optimal with Nesterov as outer and Adam as inner optimizer. To simplify the config, we don't use an Optimizer enum but Adam and Nesterov directly.

Note: This is can be seen as an improvement or down grade. I am not sure on which side I am, but it would be an option for now to simplify the code.