### PR TITLE
fix(network): log confirmed listen address

### DIFF
--- a/crates/gateway/src/network.rs
+++ b/crates/gateway/src/network.rs
@@ -172,8 +172,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
                             self.process_connection_error(&connection_id, error).await;
                         }
-                        SwarmEvent::NewListenAddr { listener_id, .. } => {
-                            self.process_new_listen_addr(&listener_id).await;
+                        SwarmEvent::NewListenAddr { listener_id, address } => {
+                            self.process_new_listen_addr(&listener_id, address).await;
                         }
                         SwarmEvent::Behaviour(BehaviourEvent::Identify(event)) => {
                             self.process_identify_event(event);

--- a/crates/network/examples/request_response/main.rs
+++ b/crates/network/examples/request_response/main.rs
@@ -236,8 +236,7 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                             self.process_connection_error(&connection_id, error).await;
                         }
                         SwarmEvent::NewListenAddr { listener_id, address, .. } => {
-                            tracing::info!("Listening on {}", address);
-                            self.process_new_listen_addr(&listener_id).await;
+                            self.process_new_listen_addr(&listener_id, address).await;
                         }
                         _ => {}
                     }

--- a/crates/network/src/listen.rs
+++ b/crates/network/src/listen.rs
@@ -85,7 +85,10 @@ where
     fn process_new_listen_addr(
         &mut self,
         listener_id: &ListenerId,
+        address: Multiaddr,
     ) -> impl Future<Output = ()> + Send {
+        tracing::info!(address=%address.clone(),"Listening");
+
         async move {
             if let Some(tx) = self.pending_listens().remove(listener_id) {
                 let _ = tx.send(Ok(()));
@@ -164,7 +167,6 @@ pub trait ListenInterface: Sync {
     ) -> impl Future<Output = Result<(), TransportError<IoError>>> + Send {
         async move {
             let (tx, rx) = oneshot::channel();
-            tracing::info!(address=%address.clone(),"Listening");
 
             self.send(ListenAction::Listen(address, tx)).await;
 

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -191,8 +191,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
                             self.process_connection_error(&connection_id, error).await;
                         }
-                        SwarmEvent::NewListenAddr { listener_id, .. } => {
-                            self.process_new_listen_addr(&listener_id).await;
+                        SwarmEvent::NewListenAddr { listener_id, address } => {
+                            self.process_new_listen_addr(&listener_id, address).await;
                         }
                         SwarmEvent::ExternalAddrConfirmed { address, .. } => {
                             self.process_confirmed_external_addr(address);

--- a/crates/worker/src/network.rs
+++ b/crates/worker/src/network.rs
@@ -189,8 +189,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
                             self.process_connection_error(&connection_id, error).await;
                         }
-                        SwarmEvent::NewListenAddr { listener_id, .. } => {
-                            self.process_new_listen_addr(&listener_id).await;
+                        SwarmEvent::NewListenAddr { listener_id, address } => {
+                            self.process_new_listen_addr(&listener_id, address).await;
                         }
                         SwarmEvent::ExternalAddrConfirmed { address, .. } => {
                             self.process_confirmed_external_addr(address);


### PR DESCRIPTION
Log the listen address not at listen request time but instead the confirmed address reported by the swarm (e.g., including OS-assigned ports).