### PR TITLE
feat: track data slice requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -167,7 +167,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -179,7 +179,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -402,7 +402,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -413,7 +413,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -439,9 +439,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -484,7 +484,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -635,7 +635,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -835,7 +835,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -920,7 +920,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -963,7 +963,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -989,7 +989,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1090,7 +1090,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1272,7 +1272,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1954,6 +1954,7 @@ dependencies = [
  "libp2p-stream",
  "miette",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2046,6 +2047,7 @@ dependencies = [
  "miette",
  "pin-project",
  "serde",
+ "serde_json",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -2284,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
@@ -2814,7 +2816,7 @@ source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747
 dependencies = [
  "heck",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2902,7 +2904,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -3017,7 +3019,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3043,13 +3045,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3075,7 +3077,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3232,7 +3234,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3356,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -3366,14 +3368,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3527,7 +3529,7 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3606,7 +3608,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3664,7 +3666,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3693,7 +3695,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3795,7 +3797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3824,7 +3826,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "version_check",
  "yansi",
 ]
@@ -3849,7 +3851,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3860,7 +3862,7 @@ checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -3892,7 +3894,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4112,7 +4114,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4161,7 +4163,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4324,7 +4326,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4333,9 +4335,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4464,7 +4466,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4520,7 +4522,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4705,7 +4707,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4748,9 +4750,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4774,7 +4776,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4783,7 +4785,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -4797,7 +4799,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -4811,7 +4813,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4897,7 +4899,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4908,7 +4910,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5000,7 +5002,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5194,7 +5196,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -5238,7 +5240,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5446,7 +5448,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.106",
+ "syn 2.0.107",
  "url",
  "uuid",
 ]
@@ -5541,7 +5543,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -5576,7 +5578,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6107,7 +6109,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -6119,7 +6121,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -6140,7 +6142,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -6160,7 +6162,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -6200,7 +6202,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -18,6 +18,7 @@ libp2p.workspace = true
 libp2p-stream.workspace = true
 miette.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
 use hypha_config::TLSConfig;
+use hypha_network::{IpNet, reserved_cidrs};
 use hypha_telemetry::{
     attributes::Attributes,
     otlp::{Endpoint, Headers, Protocol},
@@ -27,6 +28,10 @@ pub struct Config {
     listen_addresses: Vec<Multiaddr>,
     /// Path or file providing a dataset.
     dataset_path: PathBuf,
+    /// CIDR address filters applied before adding Identify-reported listen addresses to Kademlia.
+    /// Use standard CIDR notation (e.g., "10.0.0.0/8", "fc00::/7").
+    #[serde(default = "reserved_cidrs")]
+    exclude_cidr: Vec<IpNet>,
     #[serde(alias = "exporter_otlp_endpoint")]
     /// OTLP Exporter endpoint for telemetry data. If unset, telemetry is disabled.
     telemetry_endpoint: Option<Endpoint>,
@@ -72,6 +77,7 @@ impl Default for Config {
                     .expect("default address parses into a Multiaddr"),
             ],
             dataset_path: PathBuf::new(),
+            exclude_cidr: reserved_cidrs(),
             telemetry_attributes: None,
             telemetry_endpoint: None,
             telemetry_headers: None,
@@ -94,6 +100,10 @@ impl Config {
     /// Base directory for per-job working directories.
     pub fn dataset_path(&self) -> &PathBuf {
         &self.dataset_path
+    }
+
+    pub fn exclude_cidr(&self) -> &Vec<IpNet> {
+        &self.exclude_cidr
     }
 
     pub fn telemetry_endpoint(&self) -> Option<Endpoint> {

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -27,6 +27,7 @@ pub mod api {
         DispatchJob(dispatch_job::Request),
         ParameterPull(parameter_pull::Request),
         ParameterPush(parameter_push::Request),
+        Data(data::Request),
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -37,6 +38,7 @@ pub mod api {
         DispatchJob(dispatch_job::Response),
         ParameterPull(parameter_pull::Response),
         ParameterPush(parameter_push::Response),
+        Data(data::Response),
     }
 }
 
@@ -223,6 +225,9 @@ pub enum Reference {
         strategy: SelectionStrategy,
         resource: Option<DataSlice>,
     },
+
+    #[serde(rename = "scheduler")]
+    Scheduler { peer: PeerId, dataset: String },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -257,6 +262,13 @@ impl Fetch {
             peers: vec![peer_id],
             strategy: SelectionStrategy::One,
             resource: Some(resource),
+        })
+    }
+
+    pub fn scheduler(peer_id: PeerId, daset: String) -> Self {
+        Self(Reference::Scheduler {
+            peer: peer_id,
+            dataset: daset,
         })
     }
 }
@@ -554,11 +566,34 @@ pub mod parameter_push {
     }
 }
 
+pub mod data {
+    use super::*;
+
+    /// Worker requests data from data server
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        pub dataset: String,
+    }
+
+    /// Data server responds with data or error
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub enum Response {
+        Success { data_provider: PeerId, index: u64 },
+        NotFound,
+        Error(String),
+    }
+}
+
 /// Header for parameter data streams
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParameterStreamHeader {
     pub stream_id: Uuid,
     pub data_size: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataRecord {
+    pub num_slices: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -21,6 +21,7 @@ libp2p-stream.workspace = true
 miette.workspace = true
 pin-project.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod allocator;
 pub mod config;
 pub mod network;
+pub mod slice_tracker;
 pub mod worker;
-// pub mod tasks;

--- a/crates/scheduler/src/slice_tracker.rs
+++ b/crates/scheduler/src/slice_tracker.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+
+use hypha_messages::{api, data};
+use hypha_network::request_response::{
+    RequestResponseError, RequestResponseInterface, RequestResponseInterfaceExt,
+};
+use libp2p::PeerId;
+use tokio::sync::Mutex;
+
+/// SliceTracker tracks the distribution of slices of a dataset.
+///
+/// In data-parallel training, multiple participants train on different partitions of a data set.
+/// Participants can request slices of data. To ensure that each participant receives a unique slice,
+/// the SliceTracker maintains a list of available slices and assigns them to participants as they request them.
+pub struct SliceTracker<TBehaviour>
+where
+    TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
+{
+    network: TBehaviour,
+    data_provider: PeerId,
+    dataset: String,
+    available_slices: Arc<Mutex<Vec<u64>>>,
+}
+
+impl<TBehaviour> SliceTracker<TBehaviour>
+where
+    TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
+{
+    pub fn new(
+        network: TBehaviour,
+        data_provider: PeerId,
+        dataset: String,
+        num_slices: u64,
+    ) -> Self {
+        Self {
+            network,
+            data_provider,
+            dataset,
+            available_slices: Arc::new(Mutex::new((0..num_slices).collect())),
+        }
+    }
+
+    pub async fn run(self) -> Result<impl Future<Output = ()>, RequestResponseError> {
+        let d = self.dataset.clone();
+        let data_provider = self.data_provider;
+        let available_slices = self.available_slices.clone();
+
+        let future = self
+            .network
+            .on::<api::Codec, _>(move |req: &api::Request| {
+                matches!(
+                    req,
+                    api::Request::Data(
+                        data::Request { dataset }
+                    ) if dataset == &d
+                )
+            })
+            .into_stream()
+            .await?
+            .respond_with_concurrent(None, move |(peer_id, _)| {
+                tracing::debug!(%peer_id, "Received data slice request");
+                let available_slices = available_slices.clone();
+
+                async move {
+                    // Pick an available slie
+                    // To consider: We should have a form of verification of slice usage because these requests aren't idempotent.
+                    // I.e., repeated and erroneous requests can exhaust available slices without using them.
+                    // We could, e.g. reserve a slice and only consider it used once a subsequent request confirms that.
+                    // We also might need to reset the available slice for another round of picking.
+                    match available_slices.lock().await.pop() {
+                        Some(index) => {
+                            tracing::debug!(%peer_id, "Picked data slice {}", index);
+                            api::Response::Data(data::Response::Success {
+                                data_provider,
+                                index,
+                            })
+                        }
+                        None => api::Response::Data(data::Response::Error(
+                            "No available slices".to_string(),
+                        )),
+                    }
+                }
+            });
+
+        Ok(future)
+    }
+}

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -17,7 +17,7 @@ use axum::{
     routing::{get, post},
 };
 use futures_util::{StreamExt, stream};
-use hypha_messages::{Fetch, Receive, Reference, SelectionStrategy, Send};
+use hypha_messages::{Fetch, Receive, Reference, Send};
 use hypha_network::request_response::RequestResponseError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -304,10 +304,8 @@ fn validate_fetch(resource: &Fetch) -> Result<(), Error> {
             }
             Ok(())
         }
-        Reference::Peers { strategy, .. } => match strategy {
-            SelectionStrategy::One => Ok(()),
-            _ => Err(Error::InvalidStatus("unsupported strategy".into())),
-        },
+        Reference::Scheduler { .. } => Ok(()),
+        _ => Err(Error::InvalidStatus("unsupported strategy".into())),
     }
 }
 


### PR DESCRIPTION
Changes current data handling by having workers fetch data slices through requests to the scheduler. The scheduler keeps track of available slices of a dataset (as announced by a data node) and assigns these slices to the workers as they request them.

Intended as a follow-up to #64, let's merge that one first.