### PR TITLE
fix(network): filter multiaddr before seeding Kademlia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "futures-util",
+ "ipnet",
  "libp2p",
  "libp2p-stream",
  "libp2p-swarm-test",
@@ -2295,6 +2296,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
 use hypha_config::TLSConfig;
+use hypha_network::{IpNet, reserved_cidrs};
 use hypha_telemetry::{
     attributes::Attributes,
     otlp::{Endpoint, Headers, Protocol},
@@ -44,6 +45,11 @@ pub struct Config {
     /// For `traceidratio` and `parentbased_traceidratio` samplers: Sampling probability in [0..1],
     /// e.g. "0.25". Default is 1.0.
     telemetry_sample_ratio: Option<f64>,
+    /// CIDR address filters applied before adding Identify-reported listen addresses to Kademlia.
+    ///
+    /// Use standard CIDR notation (e.g., "10.0.0.0/8", "fc00::/7"). Defaults to loopback addresses.
+    #[serde(default = "reserved_cidrs")]
+    exclude_cidr: Vec<IpNet>,
 }
 
 impl Default for Config {
@@ -75,6 +81,7 @@ impl Default for Config {
             telemetry_protocol: None,
             telemetry_sampler: None,
             telemetry_sample_ratio: None,
+            exclude_cidr: reserved_cidrs(),
         }
     }
 }
@@ -112,6 +119,10 @@ impl Config {
     /// Optional traces sampler name.
     pub fn telemetry_sampler(&self) -> Option<SamplerKind> {
         self.telemetry_sampler.clone()
+    }
+
+    pub fn exclude_cidr(&self) -> &Vec<IpNet> {
+        &self.exclude_cidr
     }
 }
 

--- a/crates/gateway/src/network.rs
+++ b/crates/gateway/src/network.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
 use hypha_network::{
-    CertificateDer, CertificateRevocationListDer, PrivateKeyDer,
+    CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
     external_address::{ExternalAddressAction, ExternalAddressDriver, ExternalAddressInterface},
     gossipsub::{
@@ -62,6 +62,7 @@ pub struct NetworkDriver {
     health_outbound_requests_map: OutboundRequests<HealthCodec>,
     health_outbound_responses_map: OutboundResponses,
     health_request_handlers: Vec<RequestHandler<HealthCodec>>,
+    exclude_cidrs: Vec<IpNet>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -84,6 +85,7 @@ impl Network {
         private_key: PrivateKeyDer<'static>,
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
+        exclude_cidrs: Vec<IpNet>,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
         let meter = metrics::global::meter();
@@ -163,6 +165,7 @@ impl Network {
                 health_outbound_responses_map: HashMap::default(),
                 health_request_handlers: Vec::new(),
                 action_receiver,
+                exclude_cidrs,
             },
         ))
     }
@@ -366,6 +369,10 @@ impl KademliaDriver<Behaviour> for NetworkDriver {
 
     fn pending_bootstrap(&mut self) -> &mut Arc<SetOnce<()>> {
         &mut self.pending_bootstrap
+    }
+
+    fn exclude_cidrs(&self) -> Vec<IpNet> {
+        self.exclude_cidrs.clone()
     }
 }
 

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -19,6 +19,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+ipnet = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -45,5 +45,52 @@ pub mod stream;
 pub mod swarm;
 pub mod utils;
 
+use std::str::FromStr;
+
+// Re-export CIDR net types
+pub use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 // Re-export commonly used certificate types
 pub use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
+
+/// Loopback CIDRs.
+pub fn loopback_cidrs() -> Vec<IpNet> {
+    vec![
+        IpNet::from_str("127.0.0.0/8").expect("valid CIDR"),
+        IpNet::from_str("::1/128").expect("valid CIDR"),
+    ]
+}
+
+/// Private IPv4 CIDRs (RFC1918).
+pub fn private_cidrs() -> Vec<IpNet> {
+    vec![
+        IpNet::from_str("10.0.0.0/8").expect("valid CIDR"),
+        IpNet::from_str("172.16.0.0/12").expect("valid CIDR"),
+        IpNet::from_str("192.168.0.0/16").expect("valid CIDR"),
+    ]
+}
+
+/// link-local CIDRs.
+pub fn link_local_cidrs() -> Vec<IpNet> {
+    vec![
+        IpNet::from_str("169.254.0.0/16").expect("valid CIDR"),
+        IpNet::from_str("fe80::/10").expect("valid CIDR"),
+    ]
+}
+
+/// IPv6 unique local address CIDRs.
+pub fn unique_local_ipv6_cidrs() -> Vec<IpNet> {
+    vec![IpNet::from_str("fc00::/7").expect("valid CIDR")]
+}
+
+/// Rreserved CIDRs that should be filtered in most deployments.
+pub fn reserved_cidrs() -> Vec<IpNet> {
+    [
+        loopback_cidrs(),
+        private_cidrs(),
+        link_local_cidrs(),
+        unique_local_ipv6_cidrs(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}

--- a/crates/network/tests/kad_test.rs
+++ b/crates/network/tests/kad_test.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use futures_util::StreamExt;
 use hypha_network::{
+    IpNet,
     dial::*,
     kad::*,
     swarm::{SwarmDriver, SwarmError},
@@ -96,6 +97,10 @@ impl KademliaDriver<TestBehaviour> for TestDriver {
 
     fn pending_bootstrap(&mut self) -> &mut std::sync::Arc<tokio::sync::SetOnce<()>> {
         &mut self.pending_bootstrap
+    }
+
+    fn exclude_cidrs(&self) -> Vec<IpNet> {
+        Vec::new()
     }
 }
 

--- a/crates/scheduler/src/config.rs
+++ b/crates/scheduler/src/config.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
 use hypha_config::TLSConfig;
+use hypha_network::{IpNet, reserved_cidrs};
 use hypha_telemetry::{
     attributes::Attributes,
     otlp::{Endpoint, Headers, Protocol},
@@ -27,6 +28,10 @@ pub struct Config {
     listen_addresses: Vec<Multiaddr>,
     /// External addresses to advertise. Only list addresses that are guaranteed to be reachable from the internet.
     external_addresses: Vec<Multiaddr>,
+    /// CIDR address filters applied before adding Identify-reported listen addresses to Kademlia.
+    /// Use standard CIDR notation (e.g., "10.0.0.0/8", "fc00::/7").
+    #[serde(default = "reserved_cidrs")]
+    exclude_cidr: Vec<IpNet>,
     /// Enable listening via relay P2pCircuit through the gateway.
     /// Default is true to ensure inbound connectivity via relays.
     relay_circuit: bool,
@@ -75,6 +80,7 @@ impl Default for Config {
                     .expect("default address parses into a Multiaddr"),
             ],
             external_addresses: vec![],
+            exclude_cidr: reserved_cidrs(),
             // NOTE: Enabled by default to support inbound connectivity via relays
             // when behind NAT or firewall.
             relay_circuit: true,
@@ -99,6 +105,9 @@ impl Config {
 
     pub fn external_addresses(&self) -> &Vec<Multiaddr> {
         &self.external_addresses
+    }
+    pub fn exclude_cidr(&self) -> &Vec<IpNet> {
+        &self.exclude_cidr
     }
 
     /// Whether to listen via a relay P2pCircuit through the gateway.

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, sync::Arc};
 use futures_util::stream::StreamExt;
 use hypha_messages::{api, health};
 use hypha_network::{
-    CertificateDer, CertificateRevocationListDer, PrivateKeyDer,
+    CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
     external_address::{ExternalAddressAction, ExternalAddressDriver, ExternalAddressInterface},
     gossipsub::{
@@ -74,6 +74,7 @@ pub struct NetworkDriver {
     health_outbound_requests_map: OutboundRequests<health::Codec>,
     health_outbound_responses_map: OutboundResponses,
     health_request_handlers: HealthRequestHandlers,
+    exclude_cidrs: Vec<IpNet>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -93,6 +94,7 @@ impl Network {
         private_key: PrivateKeyDer<'static>,
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
+        exclude_cidrs: Vec<IpNet>,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
         let meter = metrics::global::meter();
@@ -181,6 +183,7 @@ impl Network {
                 health_outbound_responses_map: HashMap::default(),
                 health_request_handlers: Vec::new(),
                 action_receiver,
+                exclude_cidrs,
             },
         ))
     }
@@ -318,6 +321,10 @@ impl KademliaDriver<Behaviour> for NetworkDriver {
 
     fn pending_bootstrap(&mut self) -> &mut Arc<SetOnce<()>> {
         &mut self.pending_bootstrap
+    }
+
+    fn exclude_cidrs(&self) -> Vec<IpNet> {
+        self.exclude_cidrs.clone()
     }
 }
 impl KademliaInterface for Network {


### PR DESCRIPTION
Nodes were leaking loopback and RFC1918 listen addrs into the DHT via Identify -> Kademlia, causing peers to redial themselves and hit `WrongPeerId`/`no addresses for peer` Errors. The network crate now provides a mechanism to exclude any reported multiaddr that falls inside a configurable set of CIDR blocks before adding it to Kademlia.

A default exclusion list (loopback, private, link-local, IPv6 ULA) is provided by `reserved_cidrs()`, re-exported alongside `IpNet`. Gateway, scheduler, and worker configs/CLIs can override it with repeated `exclude_cidr` entries.

Fixes #84