### PR TITLE
fix: indent multiline field docs

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -518,6 +518,7 @@ where
     let mut header = format!("# Config\n# \n# {}\n# \n# Fields:\n", T::DOCS);
     for field in T::FIELD_NAMES {
         if let Ok(docs) = T::get_field_docs(field) {
+            let docs = docs.replace("\n", "\n#     ");
             header.push_str(&format!("# - {field}: {docs}\n"));
         }
     }


### PR DESCRIPTION
When creating an initial configuration, all configuration fields are documented. Invalid TOML was created if any of the field's doc comments consisted of multiple lines. This has been fixed by ensuring that a TOML comment is used in these cases.