### PR TITLE
feat: scheduler configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2387,9 +2387,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -3017,9 +3017,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -3473,9 +3473,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -4432,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.33"
+version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5483,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "unicode-linebreak"

--- a/crates/scheduler/src/config.rs
+++ b/crates/scheduler/src/config.rs
@@ -11,6 +11,8 @@ use hypha_telemetry::{
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 
+use crate::scheduler_config::SchedulerConfig;
+
 #[derive(Deserialize, Serialize, Documented, DocumentedFieldsOpt)]
 /// Configure scheduler network settings, security certificates, and runtime parameters.
 pub struct Config {
@@ -56,6 +58,8 @@ pub struct Config {
     telemetry_sample_ratio: Option<f64>,
     // path to AIM relay server
     status_bridge: Option<String>,
+    /// Scheduler configuration.
+    scheduler: SchedulerConfig,
 }
 
 impl Default for Config {
@@ -93,6 +97,7 @@ impl Default for Config {
             telemetry_sampler: None,
             telemetry_sample_ratio: None,
             status_bridge: Some("0.0.0.0:61000".to_string()),
+            scheduler: SchedulerConfig::default(),
         }
     }
 }
@@ -146,6 +151,10 @@ impl Config {
 
     pub fn status_bridge(&self) -> Option<String> {
         self.status_bridge.clone()
+    }
+
+    pub fn scheduler_config(&self) -> &SchedulerConfig {
+        &self.scheduler
     }
 }
 

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod allocator;
 pub mod config;
 pub mod network;
+pub mod scheduler_config;
 pub mod slice_tracker;
 pub mod status_bridge;
 pub mod worker;

--- a/crates/scheduler/src/scheduler_config.rs
+++ b/crates/scheduler/src/scheduler_config.rs
@@ -1,0 +1,197 @@
+use hypha_messages::{
+    Adam, DiLoCoConfig, Fetch, HFRepoType, Loss, Nesterov, Requirement, Resources, Scheduler,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum SchedulerConfig {
+    #[serde(rename = "diloco")]
+    DiLoCo(DiLoCo),
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        SchedulerConfig::DiLoCo(DiLoCo {
+            model: HuggingFaceSource {
+                repository: "l45k/Resnet50".to_string(),
+                revision: None,
+                filenames: vec!["config.json".to_string(), "model.safetensors".to_string()],
+                token: None,
+            },
+            dataset: DataNodeSource {
+                dataset: "imagnet".to_string(),
+            },
+            resources: DiLoCoResources {
+                num_workers: 2,
+                worker: vec![
+                    Requirement::Resource(Resources::Gpu { min: 10.0 }),
+                    Requirement::Resource(Resources::Cpu { min: 1.0 }),
+                    Requirement::Resource(Resources::Memory { min: 1.0 }),
+                    Requirement::Driver {
+                        kind: "diloco-transformer".into(),
+                    },
+                ],
+                parameter_server: vec![
+                    Requirement::Resource(Resources::Cpu { min: 1.0 }),
+                    Requirement::Resource(Resources::Memory { min: 1.0 }),
+                    Requirement::Driver {
+                        kind: "parameter-server".into(),
+                    },
+                ],
+            },
+            worker: WorkerConfig::VisionClassification {
+                optimizer: Adam {
+                    learning_rate: 1e-3,
+                    betas: None,
+                    epsilon: None,
+                },
+                epochs: 3,
+                batch_size: 126,
+                checkpointing: 1,
+                scheduler: None,
+                preprocessor: Some(HuggingFaceSource {
+                    repository: "l45k/Resnet50".to_string(),
+                    revision: None,
+                    filenames: vec!["preprocessor_config.json".to_string()],
+                    token: None,
+                }),
+                batches_per_local_epoch: 1,
+            },
+            parameter_server: ParameterServerConfig {
+                optimizer: Nesterov {
+                    learning_rate: 0.7,
+                    momentum: 0.9,
+                },
+            },
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DiLoCo {
+    pub model: HuggingFaceSource,
+    pub dataset: DataNodeSource,
+    pub resources: DiLoCoResources,
+    pub worker: WorkerConfig,
+    pub parameter_server: ParameterServerConfig,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct HuggingFaceSource {
+    pub repository: String,
+    pub revision: Option<String>,
+    pub filenames: Vec<String>,
+    pub token: Option<String>,
+}
+
+impl From<HuggingFaceSource> for Fetch {
+    fn from(source: HuggingFaceSource) -> Self {
+        Fetch::huggingface(
+            source.repository,
+            source.revision,
+            source.filenames,
+            source.token,
+            HFRepoType::Model,
+        )
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DataNodeSource {
+    pub dataset: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DiLoCoResources {
+    pub num_workers: u32,
+    pub worker: Vec<Requirement>,
+
+    pub parameter_server: Vec<Requirement>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum WorkerConfig {
+    CausalLm {
+        optimizer: Adam,
+        epochs: i32,
+        batch_size: i32,
+        checkpointing: i32,
+        scheduler: Option<Scheduler>,
+    },
+    VisionClassification {
+        optimizer: Adam,
+        epochs: i32,
+        batch_size: i32,
+        checkpointing: i32,
+        scheduler: Option<Scheduler>,
+        preprocessor: Option<HuggingFaceSource>,
+        batches_per_local_epoch: i32,
+    },
+    Torch {
+        optimizer: Adam,
+        loss_fn: Loss,
+        epochs: i32,
+        batch_size: i32,
+        checkpointing: i32,
+        scheduler: Option<Scheduler>,
+    },
+}
+
+impl From<WorkerConfig> for DiLoCoConfig {
+    fn from(value: WorkerConfig) -> Self {
+        match value {
+            WorkerConfig::CausalLm {
+                optimizer,
+                epochs,
+                batch_size,
+                checkpointing,
+                scheduler,
+            } => DiLoCoConfig::CausalLm {
+                optimizer,
+                epochs,
+                batch_size,
+                checkpointing,
+                scheduler,
+            },
+            WorkerConfig::VisionClassification {
+                optimizer,
+                epochs,
+                batch_size,
+                checkpointing,
+                scheduler,
+                preprocessor,
+                batches_per_local_epoch,
+            } => DiLoCoConfig::VisionClassification {
+                optimizer,
+                epochs,
+                batch_size,
+                checkpointing,
+                scheduler,
+                preprocessor: preprocessor.map(|p| p.into()),
+                batches_per_local_epoch,
+            },
+            WorkerConfig::Torch {
+                optimizer,
+                loss_fn,
+                epochs,
+                batch_size,
+                checkpointing,
+                scheduler,
+            } => DiLoCoConfig::Torch {
+                optimizer,
+                loss_fn,
+                epochs,
+                batch_size,
+                checkpointing,
+                scheduler,
+            },
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ParameterServerConfig {
+    pub optimizer: Nesterov,
+}


### PR DESCRIPTION
Makes the scheduler configurable by moving the hard-coded configuration values into `scheduler_config.rs`.

This is a basic approach using the existing configuration. With that, the job created using this configuration has the same runtime as the scheduler. I.e. a scheduler instance cannot create multiple jobs during its runtime. If we want to support this in the future, we need a different mechanism (e.g. an API) to scheduler jobs.

A DiLoCo configuration will look like this:

```toml
[scheduler]
type = "diloco"

[scheduler.model]
repository = "l45k/Resnet50"
filenames = [
    "config.json",
    "model.safetensors",
]

[scheduler.dataset]
dataset = "imagnet"

[scheduler.resources]
num_workers = 2

[[scheduler.resources.worker]]
type = "GPU"
min = 10.0

[[scheduler.resources.worker]]
type = "CPU"
min = 1.0

[[scheduler.resources.worker]]
type = "Memory"
min = 1.0

[[scheduler.resources.worker]]
kind = "diloco-transformer"

[[scheduler.resources.parameter_server]]
type = "CPU"
min = 1.0

[[scheduler.resources.parameter_server]]
type = "Memory"
min = 1.0

[[scheduler.resources.parameter_server]]
kind = "parameter-server"

[scheduler.worker]
type = "VisionClassification"
epochs = 3
batch_size = 126
checkpointing = 1
batches_per_local_epoch = 1

[scheduler.worker.optimizer]
learning-rate = 0.001

[scheduler.worker.preprocessor]
repository = "l45k/Resnet50"
filenames = ["preprocessor_config.json"]

[scheduler.parameter_server.optimizer]
learning-rate = 0.7
momentum = 0.9
```

Closes #76