### PR TITLE
fix(batch_scheduler): advance state with non-responsive worker

### DIFF
--- a/crates/scheduler/src/statistics.rs
+++ b/crates/scheduler/src/statistics.rs
@@ -13,7 +13,7 @@ pub struct RunningMean {
 impl RunningMean {
     fn new() -> Self {
         RunningMean {
-            running_mean: 0,
+            running_mean: u64::MAX,
             samples: 0,
         }
     }


### PR DESCRIPTION
Tis fixes the case when only a single worker starts the training and the simulation can't be performed because of missing statistics for all worker.