### PR TITLE
feat: support executor configs

### DIFF
--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ArtifactHeader {
     pub job_id: Uuid,
-    pub epoch: u64,
+    pub epoch: u32,
 }
 
 pub mod api {
@@ -94,12 +94,12 @@ pub mod progress {
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct Status {
-        pub batch_size: u64,
+        pub batch_size: u32,
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct Metrics {
-        pub round: u64,
+        pub round: u32,
         pub metrics: HashMap<String, f32>,
     }
 
@@ -110,7 +110,7 @@ pub mod progress {
         Continue,
         ScheduleUpdate {
             // Batch counter until update
-            counter: u64,
+            counter: u32,
         },
         Done,
         Error,

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -230,11 +230,8 @@ pub struct WorkerSpec {
 pub enum Requirement {
     /// Hardware requirement
     Resource(Resources),
-    // We're currently ignoring driver requirements
-    // Driver, Service
-    Driver {
-        kind: String,
-    },
+    /// Executor requirement advertised by the worker
+    Executor(ExecutorDescriptor),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -433,48 +430,168 @@ impl AsRef<Reference> for Receive {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(tag = "type", rename_all = "kebab-case")]
-pub enum DiLoCoConfig {
-    CausalLm {
-        optimizer: Adam,
-        batch_size: u32,
-        scheduler: Option<Scheduler>,
-    },
-    VisionClassification {
-        optimizer: Adam,
-        batch_size: u32,
-        scheduler: Option<Scheduler>,
-        preprocessor: Option<Fetch>,
-    },
-    Torch {
-        optimizer: Adam,
-        loss_fn: Loss,
-        batch_size: u32,
-        scheduler: Option<Scheduler>,
-    },
+/// Executor configuration payload keyed off the executor class.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "task", rename_all = "kebab-case")]
+pub enum Model {
+    VisionClassification { artifact: Fetch },
+    CausalLm { artifact: Fetch },
+    Torch { artifact: Fetch },
 }
 
-/// Driver specifications for different ML frameworks
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[non_exhaustive]
-#[serde(tag = "type")]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TrainExecutorConfig {
+    pub model: Model,
+    pub data: Fetch,
+    /// Destination to send local training updates.
+    pub updates: Send,
+    /// Stream providing aggregated parameters back to the executor.
+    pub results: Receive,
+    // TODO: Add support for additional optimizeres considering different executors and model types.
+    pub optimizer: Adam,
+    pub batch_size: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preprocessor: Option<Fetch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<Scheduler>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AggregateExecutorConfig {
+    /// Stream of updates produced by workers.
+    pub updates: Receive,
+    /// Stream used to distribute aggregated parameters back to workers.
+    pub results: Send,
+    // TODO: Add support for additional optimizeres when needed.
+    pub optimizer: Nesterov,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct TrainExecutorDescriptor {
+    name: String,
+}
+
+impl TrainExecutorDescriptor {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn into_executor(self, config: TrainExecutorConfig) -> TrainExecutor {
+        TrainExecutor {
+            descriptor: self,
+            config,
+        }
+    }
+}
+
+impl From<TrainExecutorDescriptor> for ExecutorDescriptor {
+    fn from(descriptor: TrainExecutorDescriptor) -> Self {
+        Self::Train(descriptor.clone())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AggregateExecutorDescriptor {
+    name: String,
+}
+
+impl AggregateExecutorDescriptor {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn into_executor(self, config: AggregateExecutorConfig) -> AggregateExecutor {
+        AggregateExecutor {
+            descriptor: self,
+            config,
+        }
+    }
+}
+
+impl From<AggregateExecutorDescriptor> for ExecutorDescriptor {
+    fn from(descriptor: AggregateExecutorDescriptor) -> Self {
+        Self::Aggregate(descriptor.clone())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(tag = "class", rename_all = "kebab-case")]
+pub enum ExecutorDescriptor {
+    Train(TrainExecutorDescriptor),
+    Aggregate(AggregateExecutorDescriptor),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TrainExecutor {
+    descriptor: TrainExecutorDescriptor,
+    config: TrainExecutorConfig,
+}
+
+impl TrainExecutor {
+    pub fn descriptor(&self) -> &TrainExecutorDescriptor {
+        &self.descriptor
+    }
+
+    pub fn config(&self) -> &TrainExecutorConfig {
+        &self.config
+    }
+}
+
+impl From<TrainExecutor> for Executor {
+    fn from(executor: TrainExecutor) -> Self {
+        Self::Train(executor)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AggregateExecutor {
+    descriptor: AggregateExecutorDescriptor,
+    config: AggregateExecutorConfig,
+}
+
+impl AggregateExecutor {
+    pub fn descriptor(&self) -> &AggregateExecutorDescriptor {
+        &self.descriptor
+    }
+
+    pub fn config(&self) -> &AggregateExecutorConfig {
+        &self.config
+    }
+}
+
+impl From<AggregateExecutor> for Executor {
+    fn from(executor: AggregateExecutor) -> Self {
+        Self::Aggregate(executor)
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "class", rename_all = "kebab-case")]
 pub enum Executor {
-    #[serde(rename = "diloco-transformer")]
-    DiLoCoTransformer {
-        model: Fetch,
-        data: Fetch,
-        updates: Receive,
-        results: Send,
-        config: DiLoCoConfig,
-    },
-    #[serde(rename = "parameter-server")]
-    ParameterServer {
-        updates: Receive,
-        results: Send,
-        optimizer: Nesterov,
-    },
+    Train(TrainExecutor),
+    Aggregate(AggregateExecutor),
+}
+
+// NOTE: This is not only to convert an `Executor` into an `ExecutorDescriptor` enum but also
+// ensuring that the ExecutorDescriptor and Executor arms match.
+impl From<&Executor> for ExecutorDescriptor {
+    fn from(executor: &Executor) -> Self {
+        match executor {
+            Executor::Train(TrainExecutor { descriptor, .. }) => Self::Train(descriptor.clone()),
+            Executor::Aggregate(AggregateExecutor { descriptor, .. }) => {
+                Self::Aggregate(descriptor.clone())
+            }
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/scheduler/src/batch_scheduler.rs
+++ b/crates/scheduler/src/batch_scheduler.rs
@@ -84,8 +84,9 @@ where
             tracker.update(&peer_id, batch_size)?;
             match tracker.worker_tracker.worker_state(&peer_id) {
                 State::Training => {
-                    let time_cap = 10000u64;
-                    let update_cap = 3u64;
+                    // NOTE: time_cap is u64 (time), update_cap is u32 (count)
+                    let time_cap: u64 = 10000;
+                    let update_cap: u32 = 3;
                     let (time, cnt, projection, capped) = S::project(
                         tracker.worker_tracker.last_updates(),
                         tracker.worker_tracker.batch_sizes(),

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -491,7 +491,7 @@ fn get_executor_with_dataset(
     peer_id: PeerId,
     dataset: String,
     parameter_server: PeerId,
-    batch_size: u64,
+    batch_size: u32,
 ) -> Executor {
     Executor::DiLoCoTransformer {
         model: config.model.clone().into(),

--- a/crates/scheduler/src/metrics_bridge.rs
+++ b/crates/scheduler/src/metrics_bridge.rs
@@ -18,7 +18,7 @@ pub enum MetricsError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AimMetrics {
     pub worker_id: PeerId,
-    pub round: u64,
+    pub round: u32,
     pub metric_name: String,
     pub value: f32,
 }

--- a/crates/scheduler/src/tracker/progress.rs
+++ b/crates/scheduler/src/tracker/progress.rs
@@ -10,12 +10,12 @@ pub struct ProgressTracker<T>
 where
     T: RuntimeStatistic,
 {
-    counter: u64,
+    counter: u32,
     parameter_server: PeerId,
-    update_target: u64,
+    update_target: u32,
     round_start_instant: Instant,
-    update_epochs: u64,
-    update_counter: u64,
+    update_epochs: u32,
+    update_counter: u32,
     pub worker_tracker: WorkerTracker<T>,
 }
 
@@ -23,7 +23,7 @@ impl<T> ProgressTracker<T>
 where
     T: RuntimeStatistic,
 {
-    pub fn new(parameter_server: PeerId, update_target: u64, update_epochs: u64) -> Self {
+    pub fn new(parameter_server: PeerId, update_target: u32, update_epochs: u32) -> Self {
         ProgressTracker {
             counter: update_target,
             parameter_server,
@@ -39,7 +39,7 @@ where
         self.parameter_server = new_paramter_server;
     }
 
-    pub fn update(&mut self, id: &PeerId, count: u64) -> Result<(), WorkerTrackerError> {
+    pub fn update(&mut self, id: &PeerId, count: u32) -> Result<(), WorkerTrackerError> {
         self.counter = self.counter.saturating_sub(count);
         self.worker_tracker
             .update(id, self.round_start_instant.elapsed().as_millis() as u64)?;
@@ -53,11 +53,11 @@ where
         self.worker_tracker.new_round();
     }
 
-    pub fn count(&self) -> u64 {
+    pub fn count(&self) -> u32 {
         self.counter
     }
 
-    pub fn round(&self) -> u64 {
+    pub fn round(&self) -> u32 {
         self.update_counter
     }
 

--- a/crates/scheduler/src/tracker/worker.rs
+++ b/crates/scheduler/src/tracker/worker.rs
@@ -23,7 +23,7 @@ where
 {
     pub(crate) last_update: Vec<u64>,
     peer_ids: Vec<PeerId>,
-    batch_sizes: Vec<u64>,
+    batch_sizes: Vec<u32>,
     statistics: Vec<T>,
     woker_state: Vec<State>,
 }
@@ -49,7 +49,7 @@ where
         }
     }
 
-    pub fn add_worker(&mut self, id: PeerId, batch_size: u64) {
+    pub fn add_worker(&mut self, id: PeerId, batch_size: u32) {
         self.peer_ids.push(id);
         self.batch_sizes.push(batch_size);
         self.last_update.push(0); // TODO: Need to handle this better for late arrivals
@@ -74,7 +74,7 @@ where
         Ok(())
     }
 
-    pub fn batch_sizes(&self) -> &[u64] {
+    pub fn batch_sizes(&self) -> &[u32] {
         self.batch_sizes.as_slice()
     }
 

--- a/crates/worker/src/executor/mod.rs
+++ b/crates/worker/src/executor/mod.rs
@@ -27,6 +27,8 @@ pub enum Error {
     UnsupportedOptimizer(),
     #[error("Tensor error")]
     Tensor(#[from] TensorOpError),
+    #[error("Executor configuration invalid: {0}")]
+    InvalidExecutorConfig(String),
 }
 
 pub trait JobExecutor {

--- a/crates/worker/src/executor/parameter_server.rs
+++ b/crates/worker/src/executor/parameter_server.rs
@@ -11,7 +11,7 @@ use candle_core::{
     safetensors::{Load, MmapedSafetensors},
 };
 use futures_util::StreamExt;
-use hypha_messages::progress;
+use hypha_messages::{Executor, progress};
 use libp2p::PeerId;
 use safetensors::serialize_to_file;
 use sha2::{Digest, Sha256};
@@ -86,12 +86,11 @@ impl JobExecutor for ParameterServerExecutor {
 
         let device = Device::Cpu;
 
-        let (updates, results, optimizer) = match job.executor {
-            hypha_messages::Executor::ParameterServer {
-                updates,
-                results,
-                optimizer,
-            } => (updates, results, optimizer),
+        let (updates, results, optimizer) = match &job.executor {
+            Executor::Aggregate(aggregate) => {
+                let config = aggregate.config().clone();
+                (config.updates, config.results, config.optimizer)
+            }
             _ => return Err(Error::UnsupportedJobSpec()),
         };
 

--- a/crates/worker/src/executor/process.rs
+++ b/crates/worker/src/executor/process.rs
@@ -17,6 +17,7 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use uuid::Uuid;
 
 use crate::{
+    config::{ExecutorConfig, ExecutorRuntime},
     connector::Connector,
     executor::{Error, Execution, JobExecutor, bridge::Bridge},
     network::Network,
@@ -26,6 +27,7 @@ pub struct ProcessExecutor {
     connector: Connector<Network>,
     network: Network,
     work_dir_base: PathBuf,
+    executor_config: ExecutorConfig,
 }
 
 pub struct ProcessExecution {
@@ -40,16 +42,34 @@ impl Execution for ProcessExecution {
     }
 }
 
+struct RuntimeContext {
+    socket_path: String,
+    work_dir: String,
+    job_json: String,
+}
+
+impl RuntimeContext {
+    fn new(socket_path: String, work_dir: String, job_json: String) -> Self {
+        Self {
+            socket_path,
+            work_dir,
+            job_json,
+        }
+    }
+}
+
 impl ProcessExecutor {
     pub(crate) fn new(
         connector: Connector<Network>,
         network: Network,
         work_dir_base: PathBuf,
+        executor_config: ExecutorConfig,
     ) -> Self {
         ProcessExecutor {
             connector,
             network,
             work_dir_base,
+            executor_config,
         }
     }
 }
@@ -60,16 +80,27 @@ impl JobExecutor for ProcessExecutor {
         &self,
         job: hypha_messages::JobSpec,
         cancel: CancellationToken,
-        _task_id: Uuid,
+        _job_id: Uuid,
         scheduler: PeerId,
     ) -> Result<ProcessExecution, Error> {
+        if !matches!(&job.executor, Executor::Train(_)) {
+            return Err(Error::UnsupportedJobSpec());
+        }
+
+        if !matches!(
+            self.executor_config.runtime(),
+            ExecutorRuntime::Process { .. }
+        ) {
+            return Err(Error::InvalidExecutorConfig(
+                "executor config must be process type".into(),
+            ));
+        }
+
         let id = Uuid::new_v4();
-        // NOTE: Place per-job workdir under configured base and keep socket within it
         let work_dir = self.work_dir_base.join(format!("hypha-{}", id));
         let sock_path = work_dir.join("bridge.sock");
         fs::create_dir_all(&work_dir).await?;
 
-        // NOTE: Create a bridge to allow for process <> network communication
         let bridge = Bridge::try_new(
             self.connector.clone(),
             self.network.clone(),
@@ -77,70 +108,68 @@ impl JobExecutor for ProcessExecutor {
             sock_path.clone(),
             cancel.clone(),
             job.job_id,
-            // task_id,
             scheduler,
         )
         .await?;
 
-        let job_json = serde_json::to_string(&job).expect("valid JobSpec JSON");
+        let cmd = self.executor_config.cmd().ok_or_else(|| {
+            Error::InvalidExecutorConfig("missing command for process executor".into())
+        })?;
+        let runtime = RuntimeContext::new(
+            sock_path.to_string_lossy().into_owned(),
+            work_dir.to_string_lossy().into_owned(),
+            serde_json::to_string(&job).expect("valid JobSpec JSON"),
+        );
 
-        // This should come from the config and should be bassed when crearting the executor
-        let mut process = Command::new(get_process_call(&job.executor))
-            .args(get_process_args(&job.executor))
-            .arg("--socket")
-            .args([&sock_path]) // passes the actual path
-            .args(["--work-dir"])
-            .arg(&work_dir) // passes the actual path
-            .args(["--job"])
-            .arg(job_json) // serialized JobSpec JSON
-            .stdout(Stdio::piped())
-            .spawn()?;
+        let mut process = Command::new(cmd);
+        let args = self
+            .executor_config
+            .args()
+            .iter()
+            .map(|arg| replace_placeholders(arg, &runtime))
+            .collect::<Vec<_>>();
+
+        process
+            .args(args)
+            .env("SOCKET_PATH", &runtime.socket_path)
+            .env("WORK_DIR", &runtime.work_dir)
+            .env("JOB_JSON", &runtime.job_json)
+            .stdout(Stdio::piped());
+        let mut process = process.spawn()?;
 
         let task_tracker = TaskTracker::new();
         let shutdown = cancel.clone();
         task_tracker.spawn(async move {
             let stdout = process.stdout.take().expect("stdout is available");
-
-            // Stream output.
             let mut lines = BufReader::new(stdout).lines();
 
             loop {
                 tokio::select! {
                     _ = shutdown.cancelled() => {
                         tracing::trace!("Received shutdown signal. Stopping executor process");
-
-                        // Send SIGTERM to process
-                        // TODO: This is only available in UNIX environment.
-                        //       We need to have a Windows-specific code-path
-                        //       if we want it to work there as well.
-                        if let Some(pid) = process.id() {
-                            if let Err(e) = signal::kill(Pid::from_raw(pid as pid_t), Signal::SIGTERM) {
-                                tracing::warn!(error = ?e, "Failed to send SIGTERM to executor process");
-                            }
-                        } else {
-                            tracing::trace!("Executor process already exited");
+                        if let Some(pid) = process.id()
+                            && let Err(e) = signal::kill(Pid::from_raw(pid as pid_t), Signal::SIGTERM)
+                        {
+                            tracing::warn!(error = ?e, "Failed to send SIGTERM to executor process");
                         }
                         break;
                     }
                     line = lines.next_line() => {
                         match line {
-                            Ok(Some(line)) => {
-                                println!("{line}")
-                            }
+                            Ok(Some(line)) => println!("{line}"),
                             Ok(None) => {
-                                // TODO
+                                tracing::debug!("Executor stdout stream exhausted");
+                                break;
                             }
-                            Err(_) => {
-                                // TODO
+                            Err(e) => {
+                                tracing::warn!(error = ?e, "Failed to read executor stdout");
+                                break;
                             }
                         }
                     }
-                    // Received if the driver stopped.
                     _ = process.wait() => {
                         tracing::debug!("Executor process task terminated");
-                        // TODO: Decide what to do if the process failed.
-                        //       We could, e.g., restart it.
-                        break
+                        break;
                     }
                 }
             }
@@ -149,7 +178,6 @@ impl JobExecutor for ProcessExecutor {
                 status = process.wait() => {
                     tracing::trace!(status = ?status, "Executor task exited");
                 }
-                // If the driver process does not exit in time, send SIGKILL.
                 _ = sleep(Duration::from_secs(5)) => {
                     tracing::trace!("Executor task didn't exit in time, sending SIGKILL");
                     if let Err(e) = process.kill().await {
@@ -158,49 +186,56 @@ impl JobExecutor for ProcessExecutor {
                 }
             }
 
-            // At this point the process is no longer running but the bridge still is.
-            // By cancelling here, the bridge will stop serving and terminate.
             shutdown.cancel();
-
-            // NOTE: Bridge::wait returns Result; we currently ignore errors here
-            // since we cannot propagate them.
             let _ = bridge.wait().await;
-
-            // Clean up.
             let _ = fs::remove_file(&sock_path).await;
             let _ = fs::remove_dir_all(&work_dir).await;
         });
 
         task_tracker.close();
 
-        // TODO: spawn and manage the actual process once the bridge is ready
         Ok(ProcessExecution { task_tracker })
     }
 }
 
-fn get_process_args(executor: &Executor) -> Vec<String> {
-    match executor {
-        Executor::DiLoCoTransformer { .. } => {
-            vec![
-                "run".into(),
-                "--directory".into(),
-                "drivers/hypha-accelerate-driver/src".into(),
-                "accelerate".into(),
-                "launch".into(),
-                "--config-file".into(),
-                "test.yaml".into(),
-                "training.py".into(),
-            ]
-        }
-        _ => {
-            vec![".".into()]
-        }
-    }
+fn replace_placeholders(arg: &str, ctx: &RuntimeContext) -> String {
+    arg.replace("{SOCKET_PATH}", &ctx.socket_path)
+        .replace("{WORK_DIR}", &ctx.work_dir)
+        .replace("{JOB_JSON}", &ctx.job_json)
 }
 
-fn get_process_call(executor: &Executor) -> String {
-    match executor {
-        Executor::DiLoCoTransformer { .. } => "uv".into(),
-        _ => ".".into(),
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod replace_placeholders {
+        use super::RuntimeContext;
+
+        #[test]
+        fn substitutes_all_known_tokens() {
+            let ctx = RuntimeContext::new(
+                "/tmp/socket".into(),
+                "/tmp/work".into(),
+                "{\"id\":1}".into(),
+            );
+            let arg = "run --socket {SOCKET_PATH} --dir {WORK_DIR} --job {JOB_JSON}";
+
+            let replaced = super::replace_placeholders(arg, &ctx);
+
+            assert_eq!(
+                replaced,
+                "run --socket /tmp/socket --dir /tmp/work --job {\"id\":1}"
+            );
+        }
+
+        #[test]
+        fn leaves_unknown_tokens_intact() {
+            let ctx = RuntimeContext::new("socket".into(), "work".into(), "job".into());
+            let arg = "noop {UNKNOWN} literal";
+
+            let replaced = super::replace_placeholders(arg, &ctx);
+
+            assert_eq!(replaced, arg);
+        }
     }
 }

--- a/crates/worker/src/lease_manager.rs
+++ b/crates/worker/src/lease_manager.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::resources::{
     ResourceManager, ResourceManagerError, extract_compute_resource_requirements,
-    extract_other_resource_requirements,
+    extract_executor_requirements,
 };
 
 #[derive(Debug, Clone, Error)]
@@ -103,10 +103,10 @@ where
         duration: Duration,
     ) -> Result<Lease<ResourceLease>, LeaseError> {
         let compute_resources = extract_compute_resource_requirements(&requirements);
-        let other_resources = extract_other_resource_requirements(&requirements);
+        let required_executors = extract_executor_requirements(&requirements);
         let reservation = self
             .resource_manager
-            .reserve(compute_resources, other_resources)
+            .reserve(compute_resources, required_executors)
             .await?;
 
         let result = self


### PR DESCRIPTION
Replace the hard-coded driver field with named executor descriptors, wiring workers to advertise executors, and overhaul the scheduler config to align it with the executor types.

This allows for full control over the executor configuration, enabling users to customize the behavior according to their specific needs or environment requirements, such as supporting AMD instead of NVIDIA.

N.B. This PR is based in on ~#108~ #115

Closes https://github.com/hypha-space/hypha/issues/80