### PR TITLE
refactor: separate CLIs def. and auto-generate docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2a2617956a06d4885b490697b5307ebb09fec10b088afc18c81762d848c2339"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1927,7 @@ name = "hypha-certutil"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "clap-markdown",
  "rcgen",
  "rustls",
  "thiserror 2.0.17",
@@ -1943,6 +1953,7 @@ name = "hypha-data"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "clap-markdown",
  "documented",
  "figment",
  "futures-util",
@@ -1965,6 +1976,7 @@ name = "hypha-gateway"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "clap-markdown",
  "documented",
  "figment",
  "futures-util",
@@ -2034,6 +2046,7 @@ version = "0.0.0"
 dependencies = [
  "ciborium",
  "clap",
+ "clap-markdown",
  "documented",
  "figment",
  "futures-util",
@@ -2091,6 +2104,7 @@ dependencies = [
  "candle-core",
  "ciborium",
  "clap",
+ "clap-markdown",
  "documented",
  "figment",
  "futures-util",

--- a/crates/certutil/Cargo.toml
+++ b/crates/certutil/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 publish.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
+build = "build.rs"
 
 [[bin]]
 name = "hypha-certutil"
@@ -15,3 +16,7 @@ rcgen.workspace = true
 rustls.workspace = true
 thiserror.workspace = true
 time = "0.3.41"
+
+[build-dependencies]
+clap.workspace = true
+clap-markdown = "0.1.5"

--- a/crates/certutil/build.rs
+++ b/crates/certutil/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(crate_name.to_string())
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/certutil/src/cli.rs
+++ b/crates/certutil/src/cli.rs
@@ -1,0 +1,100 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "hypha-certutil")]
+#[command(about = "Certificate utility for Hypha network", long_about = None)]
+#[command(version)]
+#[command(after_help = "For more information and examples, see the module documentation")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Generate a Root CA certificate
+    ///
+    /// This creates the root of your PKI hierarchy. In production, this would be
+    /// stored securely and used rarely. For development, you typically create one
+    /// root CA and reuse it across your test environment.
+    #[command(after_help = "Example: hypha-certutil root -n 'Test Root CA' -d certs/root")]
+    Root {
+        /// Organization name
+        #[arg(short = 'o', long)]
+        organization: String,
+
+        /// Country name (2-letter code)
+        #[arg(long, default_value = "US")]
+        country: String,
+
+        /// Common name for the Root CA (defaults to "<org> CA")
+        #[arg(short = 'n', long)]
+        name: Option<String>,
+
+        /// Directory to save the certificate and key files
+        #[arg(short, long, default_value = ".")]
+        dir: PathBuf,
+    },
+    /// Generate an Intermediate Organization CA certificate signed by Root CA
+    ///
+    /// Organization CAs represent tenants in the Hypha network. Each tenant gets
+    /// their own CA certificate that can issue certificates for their nodes.
+    /// This provides cryptographic isolation between tenants.
+    #[command(
+        after_help = "Example: hypha-certutil org --root-cert root-ca-cert.pem --root-key root-ca-key.pem -o acme-corp"
+    )]
+    Org {
+        /// Root CA certificate file path
+        #[arg(long)]
+        root_cert: PathBuf,
+
+        /// Root CA private key file path
+        #[arg(long)]
+        root_key: PathBuf,
+
+        /// Organization/tenant name (e.g., acme-corp)
+        #[arg(short = 'o', long)]
+        organization: String,
+
+        /// Common name for the Organization CA (defaults to "<org> CA")
+        #[arg(short = 'n', long)]
+        name: Option<String>,
+
+        /// Directory to save the certificate and key files
+        #[arg(short, long, default_value = ".")]
+        dir: PathBuf,
+    },
+    /// Generate a certificate signed by a CA (intermediate or root)
+    ///
+    /// Node certificates are used by individual services and nodes in the network.
+    /// They should typically be signed by an Organization CA, not the root CA directly.
+    /// The certificate will include a trust file (bundle) for easy deployment.
+    #[command(
+        after_help = "Example: hypha-certutil node --ca-cert acme-ca-cert.pem --ca-key acme-ca-key.pem -n node1.acme.local -s node1.acme.local,*.acme.local"
+    )]
+    Node {
+        /// CA certificate file path
+        #[arg(long)]
+        ca_cert: PathBuf,
+
+        /// CA private key file path
+        #[arg(long)]
+        ca_key: PathBuf,
+
+        /// Common name for the certificate (e.g., node1.acme-corp.hypha.network)
+        #[arg(short = 'n', long)]
+        name: String,
+
+        /// Subject Alternative Names (SANs) - DNS names, IPs, etc.
+        /// Format: comma-separated list of DNS names and IP addresses
+        /// The common name will be automatically added if not present
+        #[arg(short, long, value_delimiter = ',', default_value = "0.0.0.0")]
+        san: Vec<String>,
+
+        /// Directory to save the certificate and key files
+        #[arg(short, long, default_value = ".")]
+        dir: PathBuf,
+    },
+}

--- a/crates/certutil/src/main.rs
+++ b/crates/certutil/src/main.rs
@@ -59,12 +59,9 @@
 //!                     -d certs/tenants/acme
 //! ```
 //!
-use std::{
-    fs, io,
-    path::{Path, PathBuf},
-};
+use std::{fs, io, path::Path};
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use rcgen::{
     BasicConstraints, Certificate, CertificateParams, DnType, DnValue, ExtendedKeyUsagePurpose,
     IsCa, KeyPair, KeyUsagePurpose, PKCS_ED25519,
@@ -82,102 +79,9 @@ pub enum CertError {
     Load(String),
 }
 
-#[derive(Parser)]
-#[command(name = "hypha-certutil")]
-#[command(about = "Certificate utility for Hypha network", long_about = None)]
-#[command(version)]
-#[command(after_help = "For more information and examples, see the module documentation")]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Generate a Root CA certificate
-    ///
-    /// This creates the root of your PKI hierarchy. In production, this would be
-    /// stored securely and used rarely. For development, you typically create one
-    /// root CA and reuse it across your test environment.
-    #[command(after_help = "Example: hypha-certutil root -n 'Test Root CA' -d certs/root")]
-    Root {
-        /// Organization name
-        #[arg(short = 'o', long)]
-        organization: String,
-
-        /// Country name (2-letter code)
-        #[arg(long, default_value = "US")]
-        country: String,
-
-        /// Common name for the Root CA (defaults to "<org> CA")
-        #[arg(short = 'n', long)]
-        name: Option<String>,
-
-        /// Directory to save the certificate and key files
-        #[arg(short, long, default_value = ".")]
-        dir: PathBuf,
-    },
-    /// Generate an Intermediate Organization CA certificate signed by Root CA
-    ///
-    /// Organization CAs represent tenants in the Hypha network. Each tenant gets
-    /// their own CA certificate that can issue certificates for their nodes.
-    /// This provides cryptographic isolation between tenants.
-    #[command(
-        after_help = "Example: hypha-certutil org --root-cert root-ca-cert.pem --root-key root-ca-key.pem -o acme-corp"
-    )]
-    Org {
-        /// Root CA certificate file path
-        #[arg(long)]
-        root_cert: PathBuf,
-
-        /// Root CA private key file path
-        #[arg(long)]
-        root_key: PathBuf,
-
-        /// Organization/tenant name (e.g., acme-corp)
-        #[arg(short = 'o', long)]
-        organization: String,
-
-        /// Common name for the Organization CA (defaults to "<org> CA")
-        #[arg(short = 'n', long)]
-        name: Option<String>,
-
-        /// Directory to save the certificate and key files
-        #[arg(short, long, default_value = ".")]
-        dir: PathBuf,
-    },
-    /// Generate a certificate signed by a CA (intermediate or root)
-    ///
-    /// Node certificates are used by individual services and nodes in the network.
-    /// They should typically be signed by an Organization CA, not the root CA directly.
-    /// The certificate will include a trust file (bundle) for easy deployment.
-    #[command(
-        after_help = "Example: hypha-certutil node --ca-cert acme-ca-cert.pem --ca-key acme-ca-key.pem -n node1.acme.local -s node1.acme.local,*.acme.local"
-    )]
-    Node {
-        /// CA certificate file path
-        #[arg(long)]
-        ca_cert: PathBuf,
-
-        /// CA private key file path
-        #[arg(long)]
-        ca_key: PathBuf,
-
-        /// Common name for the certificate (e.g., node1.acme-corp.hypha.network)
-        #[arg(short = 'n', long)]
-        name: String,
-
-        /// Subject Alternative Names (SANs) - DNS names, IPs, etc.
-        /// Format: comma-separated list of DNS names and IP addresses
-        /// The common name will be automatically added if not present
-        #[arg(short, long, value_delimiter = ',', default_value = "0.0.0.0")]
-        san: Vec<String>,
-
-        /// Directory to save the certificate and key files
-        #[arg(short, long, default_value = ".")]
-        dir: PathBuf,
-    },
-}
+#[path = "cli.rs"]
+mod cli;
+use cli::{Cli, Commands};
 
 /// Generate a Root CA certificate
 fn generate_root_ca_certificate(

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 publish.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 clap.workspace = true
@@ -22,3 +23,8 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[build-dependencies]
+clap.workspace = true
+serde.workspace = true
+clap-markdown = "0.1.5"

--- a/crates/data/build.rs
+++ b/crates/data/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(crate_name.to_string())
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/data/src/cli.rs
+++ b/crates/data/src/cli.rs
@@ -1,0 +1,68 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use serde::Serialize;
+
+#[derive(Debug, Parser, Serialize)]
+#[command(
+    name = "hypha-data",
+    version,
+    about = "Hypha Data Node",
+    long_about = "Runs a Hypha Data Node which provides data.",
+    after_help = "For more information, see the project documentation."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, Serialize)]
+pub enum Commands {
+    Init {
+        /// Path where the configuration file will be written
+        #[clap(short, long, default_value = "config.toml")]
+        output: PathBuf,
+    },
+    /// Probe a target multiaddr for readiness and exit 0 if healthy.
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
+        /// Timeout in milliseconds
+        #[clap(long, default_value_t = 2000)]
+        timeout: u64,
+
+        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
+        #[clap(index = 1)]
+        address: String,
+    },
+    #[serde(untagged)]
+    Run {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        #[serde(skip)]
+        config_file: PathBuf,
+    },
+}

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 publish.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 clap.workspace = true
@@ -20,3 +21,10 @@ serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[build-dependencies]
+clap.workspace = true
+hypha-network.workspace = true
+libp2p.workspace = true
+serde.workspace = true
+clap-markdown = "0.1.5"

--- a/crates/gateway/build.rs
+++ b/crates/gateway/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(crate_name.to_string())
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/gateway/src/bin/hypha-gateway.rs
+++ b/crates/gateway/src/bin/hypha-gateway.rs
@@ -1,6 +1,5 @@
 use std::{
     fs,
-    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -8,124 +7,27 @@ use std::{
     time::Duration,
 };
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use figment::providers::{Env, Format, Serialized, Toml};
 use futures_util::future::join_all;
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_gateway::{config::Config, network::Network};
 use hypha_messages::health;
 use hypha_network::{
-    IpNet, dial::DialInterface, external_address::ExternalAddressInterface,
-    listen::ListenInterface, request_response::RequestResponseInterfaceExt, swarm::SwarmDriver,
+    dial::DialInterface, external_address::ExternalAddressInterface, listen::ListenInterface,
+    request_response::RequestResponseInterfaceExt, swarm::SwarmDriver,
 };
 use hypha_telemetry as telemetry;
 use libp2p::Multiaddr;
 use miette::{IntoDiagnostic, Result};
-use serde::Serialize;
 use tokio::signal::unix::{SignalKind, signal};
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
-#[derive(Debug, Parser, Serialize)]
-#[command(
-    name = "hypha-gateway",
-    version,
-    about = "Hypha Gateway Node",
-    long_about = "Runs the Hypha Gateway facilitating network connectivity between peers.",
-    after_help = "For more information, see the project documentation."
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Debug, Subcommand, Serialize)]
-enum Commands {
-    Init {
-        /// Path where the configuration file will be written
-        #[clap(short, long, default_value = "config.toml")]
-        output: PathBuf,
-    },
-    /// Probe a target multiaddr for readiness and exit 0 if healthy.
-    #[serde(untagged)]
-    Probe {
-        /// Path to the configuration file.
-        #[clap(short, long("config"), default_value = "config.toml")]
-        config_file: PathBuf,
-
-        /// Path to the certificate pem.
-        #[clap(long("cert"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        cert_pem: Option<PathBuf>,
-
-        /// Path to the private key pem.
-        #[clap(long("key"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        key_pem: Option<PathBuf>,
-
-        /// Path to the trust pem (bundle).
-        #[clap(long("trust"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        trust_pem: Option<PathBuf>,
-
-        /// Path to the certificate revocation list pem.
-        #[clap(long("crls"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        crls_pem: Option<PathBuf>,
-
-        /// Timeout in milliseconds
-        #[clap(long, default_value_t = 2000)]
-        timeout: u64,
-
-        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
-        #[clap(index = 1)]
-        address: String,
-    },
-    #[serde(untagged)]
-    Run {
-        /// Path to the configuration file.
-        #[clap(short, long("config"), default_value = "config.toml")]
-        #[serde(skip)]
-        config_file: PathBuf,
-
-        /// Path to the certificate pem.
-        #[clap(long("cert"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        cert_pem: Option<PathBuf>,
-
-        /// Path to the private key pem.
-        #[clap(long("key"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        key_pem: Option<PathBuf>,
-
-        /// Path to the trust pem (bundle).
-        #[clap(long("trust"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        trust_pem: Option<PathBuf>,
-
-        /// Path to the certificate revocation list pem.
-        #[clap(long("crls"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        crls_pem: Option<PathBuf>,
-
-        /// Addresses to listen on (can be specified multiple times).
-        #[clap(long("listen"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        listen_addresses: Option<Vec<Multiaddr>>,
-
-        /// External addresses to advertise (can be specified multiple times).
-        #[clap(long("external"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        external_addresses: Option<Vec<Multiaddr>>,
-
-        /// CIDR exclusion (repeatable). Overrides config if provided.
-        /// Example: --exclude-cidr 10.0.0.0/8 --exclude-cidr fc00::/7
-        #[clap(long("exclude-cidr"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        exclude_cidr: Option<Vec<IpNet>>,
-    },
-}
+#[path = "../cli.rs"]
+mod cli;
+use cli::{Cli, Commands};
 
 async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     let tracing = telemetry::tracing(

--- a/crates/gateway/src/cli.rs
+++ b/crates/gateway/src/cli.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use hypha_network::IpNet;
+use libp2p::Multiaddr;
+use serde::Serialize;
+
+#[derive(Debug, Parser, Serialize)]
+#[command(
+    name = "hypha-gateway",
+    version,
+    about = "Hypha Gateway Node",
+    long_about = "Runs the Hypha Gateway facilitating network connectivity between peers.",
+    after_help = "For more information, see the project documentation."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, Serialize)]
+pub enum Commands {
+    Init {
+        /// Path where the configuration file will be written
+        #[clap(short, long, default_value = "config.toml")]
+        output: PathBuf,
+    },
+    /// Probe a target multiaddr for readiness and exit 0 if healthy.
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
+        /// Timeout in milliseconds
+        #[clap(long, default_value_t = 2000)]
+        timeout: u64,
+
+        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
+        #[clap(index = 1)]
+        address: String,
+    },
+    #[serde(untagged)]
+    Run {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        #[serde(skip)]
+        config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
+        /// Addresses to listen on (can be specified multiple times).
+        #[clap(long("listen"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        listen_addresses: Option<Vec<Multiaddr>>,
+
+        /// External addresses to advertise (can be specified multiple times).
+        #[clap(long("external"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        external_addresses: Option<Vec<Multiaddr>>,
+
+        /// CIDR exclusion (repeatable). Overrides config if provided.
+        /// Example: --exclude-cidr 10.0.0.0/8 --exclude-cidr fc00::/7
+        #[clap(long("exclude-cidr"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exclude_cidr: Option<Vec<IpNet>>,
+    },
+}

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 publish.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 ciborium.workspace = true
@@ -31,6 +32,13 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+
+[build-dependencies]
+clap.workspace = true
+hypha-network.workspace = true
+libp2p.workspace = true
+serde.workspace = true
+clap-markdown = "0.1.5"
 
 [dev-dependencies]
 tokio = { version = "1.43.0", features = [

--- a/crates/scheduler/build.rs
+++ b/crates/scheduler/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(crate_name.to_string())
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/scheduler/src/cli.rs
+++ b/crates/scheduler/src/cli.rs
@@ -1,0 +1,96 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use hypha_network::IpNet;
+use libp2p::Multiaddr;
+use serde::Serialize;
+
+#[derive(Debug, Parser, Serialize)]
+#[command(
+    name = "hypha-scheduler",
+    version,
+    about = "Hypha Scheduler",
+    long_about = "Runs the Hypha Scheduler coordinating workers.",
+    after_help = "For more information, see the project documentation."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, Serialize)]
+pub enum Commands {
+    Init {
+        /// Path where the configuration file will be written
+        #[clap(short, long, default_value = "config.toml")]
+        output: PathBuf,
+    },
+    /// Probe a target multiaddr for readiness and exit 0 if healthy.
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
+        /// Timeout in milliseconds
+        #[clap(long, default_value_t = 2000)]
+        timeout: u64,
+
+        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
+        #[clap(index = 1)]
+        address: String,
+    },
+    #[serde(untagged)]
+    Run {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        #[serde(skip)]
+        config_file: PathBuf,
+
+        /// Addresses of the gateways (can be specified multiple times).
+        #[clap(long("gateway"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
+        /// Addresses to listen on (can be specified multiple times).
+        #[clap(long("listen"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        listen_addresses: Option<Vec<Multiaddr>>,
+
+        /// External addresses to advertise (can be specified multiple times).
+        #[clap(long("external"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        external_addresses: Option<Vec<Multiaddr>>,
+
+        /// Enable listening via relay P2pCircuit (via gateway). Defaults to true.
+        #[clap(long("relay-circuit"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        relay_circuit: Option<bool>,
+
+        /// CIDR exclusion (repeatable). Overrides config if provided.
+        /// Example: --exclude-cidr 10.0.0.0/8 --exclude-cidr fc00::/7
+        #[clap(long("exclude-cidr"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exclude_cidr: Option<Vec<IpNet>>,
+    },
+}

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 publish.workspace = true
 edition.workspace = true
 license = "Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 axum.workspace = true
@@ -38,6 +39,13 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 utoipa.workspace = true
 uuid.workspace = true
+
+[build-dependencies]
+clap.workspace = true
+hypha-network.workspace = true
+libp2p.workspace = true
+serde.workspace = true
+clap-markdown = "0.1.5"
 
 [dev-dependencies]
 http-body-util.workspace = true

--- a/crates/worker/build.rs
+++ b/crates/worker/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(crate_name.to_string())
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/worker/src/bin/hypha-worker.rs
+++ b/crates/worker/src/bin/hypha-worker.rs
@@ -2,20 +2,19 @@
 
 use std::{
     env, fs,
-    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
 };
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::Parser;
 use figment::providers::{Env, Format, Serialized, Toml};
 use futures_util::future::join_all;
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_messages::health;
 use hypha_network::{
-    IpNet, dial::DialInterface, external_address::ExternalAddressInterface, kad::KademliaInterface,
+    dial::DialInterface, external_address::ExternalAddressInterface, kad::KademliaInterface,
     listen::ListenInterface, request_response::RequestResponseInterfaceExt, swarm::SwarmDriver,
 };
 use hypha_telemetry as telemetry;
@@ -26,120 +25,15 @@ use hypha_worker::{
 };
 use libp2p::{Multiaddr, multiaddr::Protocol};
 use miette::{IntoDiagnostic, Result};
-use serde::{Deserialize, Serialize};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
-#[derive(Clone, Debug, ValueEnum, Serialize, Deserialize)]
-enum Role {
-    Worker,
-    ParameterServer,
-}
-
-#[derive(Debug, Parser)]
-#[command(
-    name = "hypha-worker",
-    version,
-    about = "Hypha Worker Node",
-    long_about = "Runs a Hypha Worker which executes jobs.",
-    after_help = "For more information, see the project documentation."
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Debug, Subcommand, Serialize)]
-enum Commands {
-    Init {
-        /// Path where the configuration file will be written
-        #[clap(short, long, default_value = "config.toml")]
-        output: PathBuf,
-    },
-
-    /// Probe a target multiaddr for readiness and exit 0 if healthy.
-    #[serde(untagged)]
-    Probe {
-        /// Path to the configuration file.
-        #[clap(short, long("config"), default_value = "config.toml")]
-        config_file: PathBuf,
-
-        /// Path to the certificate pem.
-        #[clap(long("cert"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        cert_pem: Option<PathBuf>,
-
-        /// Path to the private key pem.
-        #[clap(long("key"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        key_pem: Option<PathBuf>,
-
-        /// Path to the trust pem (bundle).
-        #[clap(long("trust"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        trust_pem: Option<PathBuf>,
-
-        /// Path to the certificate revocation list pem.
-        #[clap(long("crls"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        crls_pem: Option<PathBuf>,
-
-        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
-        #[clap(index = 1)]
-        address: String,
-
-        /// Timeout in milliseconds
-        #[clap(long, default_value_t = 2000)]
-        timeout: u64,
-    },
-    #[serde(untagged)]
-    Run {
-        /// Path to the configuration file.
-        #[clap(short, long("config"), default_value = "config.toml")]
-        #[serde(skip)]
-        config_file: PathBuf,
-
-        /// Addresses of the gateways (can be specified multiple times).
-        #[clap(long("gateway"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        gateway_addresses: Option<Vec<Multiaddr>>,
-
-        /// Addresses to listen on (can be specified multiple times).
-        #[clap(long("listen"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        listen_addresses: Option<Vec<Multiaddr>>,
-
-        /// External addresses to advertise (can be specified multiple times).
-        #[clap(long("external"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        external_addresses: Option<Vec<Multiaddr>>,
-
-        /// Enable listening via relay P2pCircuit (via gateway). Defaults to true.
-        #[clap(long("relay-circuit"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        relay_circuit: Option<bool>,
-
-        /// Socket to use for driver communication.
-        #[clap(long("socket"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        socket_address: Option<PathBuf>,
-
-        /// Base directory for per-job working directories (default: /tmp).
-        /// Example: --work-dir /mnt/tmp
-        #[clap(long("work-dir"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        work_dir: Option<PathBuf>,
-
-        /// CIDR exclusion (repeatable). Overrides config if provided.
-        /// Example: --exclude-cidr 10.0.0.0/8 --exclude-cidr fc00::/7
-        #[clap(long("exclude-cidr"))]
-        #[serde(skip_serializing_if = "Option::is_none")]
-        exclude_cidr: Option<Vec<IpNet>>,
-    },
-}
+#[path = "../cli.rs"]
+mod cli;
+use cli::{Cli, Commands};
 
 async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     let tracing = telemetry::tracing(

--- a/crates/worker/src/cli.rs
+++ b/crates/worker/src/cli.rs
@@ -1,0 +1,114 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use hypha_network::IpNet;
+use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, ValueEnum, Serialize, Deserialize)]
+pub enum Role {
+    Worker,
+    ParameterServer,
+}
+
+#[derive(Debug, Parser, Serialize)]
+#[command(
+    name = "hypha-worker",
+    version,
+    about = "Hypha Worker Node",
+    long_about = "Runs a Hypha Worker which executes jobs.",
+    after_help = "For more information, see the project documentation."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, Serialize)]
+pub enum Commands {
+    Init {
+        /// Path where the configuration file will be written
+        #[clap(short, long, default_value = "config.toml")]
+        output: PathBuf,
+    },
+
+    /// Probe a target multiaddr for readiness and exit 0 if healthy.
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        config_file: PathBuf,
+
+        /// Path to the certificate pem.
+        #[clap(long("cert"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key pem.
+        #[clap(long("key"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust pem (bundle).
+        #[clap(long("trust"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list pem.
+        #[clap(long("crls"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+
+        /// Target multiaddr to probe (e.g., /ip4/127.0.0.1/tcp/8080)
+        #[clap(index = 1)]
+        address: String,
+
+        /// Timeout in milliseconds
+        #[clap(long, default_value_t = 2000)]
+        timeout: u64,
+    },
+    #[serde(untagged)]
+    Run {
+        /// Path to the configuration file.
+        #[clap(short, long("config"), default_value = "config.toml")]
+        #[serde(skip)]
+        config_file: PathBuf,
+
+        /// Addresses of the gateways (can be specified multiple times).
+        #[clap(long("gateway"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
+        /// Addresses to listen on (can be specified multiple times).
+        #[clap(long("listen"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        listen_addresses: Option<Vec<Multiaddr>>,
+
+        /// External addresses to advertise (can be specified multiple times).
+        #[clap(long("external"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        external_addresses: Option<Vec<Multiaddr>>,
+
+        /// Enable listening via relay P2pCircuit (via gateway). Defaults to true.
+        #[clap(long("relay-circuit"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        relay_circuit: Option<bool>,
+
+        /// Socket to use for driver communication.
+        #[clap(long("socket"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        socket_address: Option<PathBuf>,
+
+        /// Base directory for per-job working directories (default: /tmp).
+        /// Example: --work-dir /mnt/tmp
+        #[clap(long("work-dir"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        work_dir: Option<PathBuf>,
+
+        /// CIDR exclusion (repeatable). Overrides config if provided.
+        /// Example: --exclude-cidr 10.0.0.0/8 --exclude-cidr fc00::/7
+        #[clap(long("exclude-cidr"))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exclude_cidr: Option<Vec<IpNet>>,
+    },
+}


### PR DESCRIPTION
Split each binary’s CLI structs into `src/cli.rs` and add `build.rs` scripts to generate documentation for the different CLIs.