### PR TITLE
feat: data scheduling

### DIFF
--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -178,7 +178,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         |(peer_id, resource, mut stream)| {
             let dataset_files = dataset_files.clone();
             async move {
-                tracing::info!(peer_id = %peer_id, dataset = resource.dataset, "Sending tensor to peer");
+                tracing::info!(peer_id = %peer_id, dataset = resource.dataset, slice= resource.index, "Sending tensor to peer");
 
                 if dataset_name == resource.dataset.as_str() {
                     // Use the provided offsets to select a subset of the available dataset files.

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod allocator;
-pub mod batch_scheduler;
 pub mod config;
 pub mod metrics_bridge;
 pub mod network;
 pub mod scheduler_config;
+pub mod scheduling;
 pub mod simulation;
 pub mod statistics;
 pub mod task;

--- a/crates/scheduler/src/scheduling/batch_scheduler.rs
+++ b/crates/scheduler/src/scheduling/batch_scheduler.rs
@@ -239,8 +239,8 @@ mod batch_scheduler_tests {
     };
     use uuid::Uuid;
 
+    use super::schedule;
     use crate::{
-        batch_scheduler::schedule,
         simulation::BasicSimulation,
         statistics::RunningMean,
         tracker::{progress::ProgressTracker, worker::State},

--- a/crates/scheduler/src/scheduling/data_scheduler.rs
+++ b/crates/scheduler/src/scheduling/data_scheduler.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use hypha_messages::{api, data};
+use hypha_network::request_response::{
+    RequestResponseError, RequestResponseInterface, RequestResponseInterfaceExt,
+};
+use libp2p::PeerId;
+use thiserror::Error;
+use tokio::{sync::Mutex, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use crate::tracker::slice::SliceTracker;
+
+#[derive(Debug, Error)]
+pub enum DataSchedulerError {
+    #[error("Disconnected")]
+    Disconnected,
+    #[error("Network error")]
+    NetworkError(#[from] RequestResponseError),
+}
+
+/// DataScheduler manges the distribution of slices of a dataset.
+///
+/// In data-parallel training, multiple participants train on different partitions of a data set.
+/// Participants can request slices of data. To ensure that each participant receives a unique slice,
+/// the DataScheduler uses a `SliceTracker` that maintains a list of available slices and
+/// their stats to assigns slices to participants as they request them.
+pub struct DataScheduler<TBehaviour>
+where
+    TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
+{
+    network: TBehaviour,
+    data_provider: PeerId,
+    dataset: String,
+    slice_tracker: Arc<Mutex<SliceTracker>>,
+}
+
+impl<TBehaviour> DataScheduler<TBehaviour>
+where
+    TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
+{
+    pub fn new(
+        network: TBehaviour,
+        data_provider: PeerId,
+        dataset: String,
+        num_slices: u64,
+    ) -> Self {
+        Self {
+            network,
+            data_provider,
+            dataset,
+            slice_tracker: Arc::new(Mutex::new(SliceTracker::new(num_slices))),
+        }
+    }
+
+    pub async fn run(
+        self,
+        cancel_token: CancellationToken,
+    ) -> Result<JoinHandle<()>, DataSchedulerError> {
+        let d = self.dataset.clone();
+        let data_provider = self.data_provider;
+        let tracker = self.slice_tracker.clone();
+        let stream_handle = tokio::spawn({
+            self.network
+                .on::<api::Codec, _>(move |req: &api::Request| {
+                    matches!(
+                        req,
+                        api::Request::Data(
+                            data::Request { dataset }
+                        ) if dataset == &d
+                    )
+                })
+                .into_stream()
+                .await
+                .map_err(DataSchedulerError::from)?
+                .respond_with_concurrent(None, move |request| {
+                    let tracker = tracker.clone();
+                    async move {
+                        let peer_id = request.0;
+                        tracing::debug!(%peer_id, "Received data slice request");
+                        let index = tracker.lock().await.next(&peer_id);
+                        tracing::debug!(%peer_id, "Picked data slice {}", index);
+                        api::Response::Data(data::Response::Success {
+                            data_provider,
+                            index,
+                        })
+                    }
+                })
+        });
+
+        let handle = tokio::spawn(async move {
+            tokio::select! {
+                _ = stream_handle => {
+                    tracing::info!("Data handler finished.");
+                },
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Job is completed.");
+                }
+            }
+        });
+        Ok(handle)
+    }
+}

--- a/crates/scheduler/src/scheduling/mod.rs
+++ b/crates/scheduler/src/scheduling/mod.rs
@@ -1,0 +1,2 @@
+pub mod batch_scheduler;
+pub mod data_scheduler;

--- a/crates/scheduler/src/tracker/slice.rs
+++ b/crates/scheduler/src/tracker/slice.rs
@@ -1,87 +1,203 @@
-use std::sync::Arc;
+use std::{collections::HashMap, ops::BitAnd};
 
-use hypha_messages::{api, data};
-use hypha_network::request_response::{
-    RequestResponseError, RequestResponseInterface, RequestResponseInterfaceExt,
-};
+use itertools::Itertools;
 use libp2p::PeerId;
-use tokio::sync::Mutex;
+use thiserror::Error;
 
-/// SliceTracker tracks the distribution of slices of a dataset.
-///
-/// In data-parallel training, multiple participants train on different partitions of a data set.
-/// Participants can request slices of data. To ensure that each participant receives a unique slice,
-/// the SliceTracker maintains a list of available slices and assigns them to participants as they request them.
-pub struct SliceTracker<TBehaviour>
-where
-    TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
-{
-    network: TBehaviour,
-    data_provider: PeerId,
-    dataset: String,
-    available_slices: Arc<Mutex<Vec<u64>>>,
+#[derive(Debug, Error)]
+pub enum SliceError {
+    #[error("Not found")]
+    NotFound,
+    #[error("Slice is in a wrong state")]
+    State,
+    #[error("Error during scheduling {0}")]
+    Scheduling(String),
 }
 
-impl<TBehaviour> SliceTracker<TBehaviour>
-where
-    TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
-{
-    pub fn new(
-        network: TBehaviour,
-        data_provider: PeerId,
-        dataset: String,
-        num_slices: u64,
-    ) -> Self {
+#[derive(Debug, Clone, Copy)]
+pub struct Slice {
+    id: u64,
+    peer: Option<PeerId>,
+    processed: bool,
+}
+
+impl Slice {
+    pub fn new(id: u64) -> Self {
+        Slice {
+            id,
+            peer: None,
+            processed: false,
+        }
+    }
+}
+
+/// This tracks the data slices provided by a data node.
+pub struct SliceTracker {
+    slices: Vec<Slice>,
+    processing: HashMap<PeerId, u64>,
+    rounds: u32,
+}
+
+impl SliceTracker {
+    pub fn new(num_slices: u64) -> Self {
         Self {
-            network,
-            data_provider,
-            dataset,
-            available_slices: Arc::new(Mutex::new((0..num_slices).collect())),
+            slices: Vec::from_iter((0..num_slices).map(Slice::new)),
+            processing: HashMap::new(),
+            rounds: 0,
         }
     }
 
-    pub async fn run(self) -> Result<impl Future<Output = ()>, RequestResponseError> {
-        let d = self.dataset.clone();
-        let data_provider = self.data_provider;
-        let available_slices = self.available_slices.clone();
+    pub fn next(&mut self, peer: &PeerId) -> u64 {
+        let open_slice = self
+            .slices
+            .iter_mut()
+            .find(|s| (!s.processed).bitand(s.peer.is_none_or(|id| &id == peer)));
 
-        let future = self
-            .network
-            .on::<api::Codec, _>(move |req: &api::Request| {
-                matches!(
-                    req,
-                    api::Request::Data(
-                        data::Request { dataset }
-                    ) if dataset == &d
-                )
-            })
-            .into_stream()
-            .await?
-            .respond_with_concurrent(None, move |(peer_id, _)| {
-                tracing::debug!(%peer_id, "Received data slice request");
-                let available_slices = available_slices.clone();
-
-                async move {
-                    // Pick an available slie
-                    // To consider: We should have a form of verification of slice usage because these requests aren't idempotent.
-                    // I.e., repeated and erroneous requests can exhaust available slices without using them.
-                    // We could, e.g. reserve a slice and only consider it used once a subsequent request confirms that.
-                    // We also might need to reset the available slice for another round of picking.
-                    match available_slices.lock().await.pop() {
-                        Some(index) => {
-                            tracing::debug!(%peer_id, "Picked data slice {}", index);
-                            api::Response::Data(data::Response::Success {
-                                data_provider,
-                                index,
-                            })
+        // check if something is open
+        match open_slice {
+            Some(slice) => {
+                slice.processed = true;
+                slice.peer = Some(*peer);
+                self.processing.insert(*peer, slice.id);
+                slice.id
+            }
+            None => {
+                // We use a cache stealing strategy. If a worker is slower, other workers can steal their cached data.
+                let open_slices = self.slices.iter().filter(|&s| !s.processed);
+                let mut counts: HashMap<PeerId, u32> = HashMap::new();
+                for s in open_slices {
+                    // unwrap is fine otherwise the open_slice filter would have failed
+                    let slice_peer_id = s.peer.expect("Slice");
+                    counts
+                        .entry(slice_peer_id)
+                        .and_modify(|f| *f += 1)
+                        .or_insert(0);
+                }
+                let slow_peer = counts.iter().sorted_by_key(|f| f.1).next();
+                match slow_peer {
+                    Some((p, count)) => {
+                        tracing::info!(peer=%p, open_slices=&count, "Slowest peer with open slices. Steal slice.");
+                        // unwrap is ok since we have at least one entry
+                        let slice = self
+                            .slices
+                            .iter_mut()
+                            .find(|s| (!s.processed).bitand(s.peer.is_none_or(|id| &id == p)))
+                            .expect("Slice");
+                        slice.processed = true;
+                        slice.peer = Some(*peer);
+                        self.processing.insert(*peer, slice.id);
+                        slice.id
+                    }
+                    None => {
+                        tracing::info!("All slices have been processed. Start new round");
+                        self.rounds += 1;
+                        for s in self.slices.iter_mut() {
+                            s.processed = false;
                         }
-                        None => api::Response::Data(data::Response::Error(
-                            "No available slices".to_string(),
-                        )),
+                        // Start again
+                        self.next(peer)
                     }
                 }
-            });
+            }
+        }
+    }
 
-        Ok(future)
+    pub fn remove_worker(&mut self, peer: &PeerId) {
+        while let Some(s) = self.slices.iter_mut().find(|s| s.peer == Some(*peer)) {
+            s.peer = None;
+        }
+        if let Some(s_id) = self.processing.remove(peer)
+            && let Some(slice) = self.slices.iter_mut().find(|s| s.id == s_id)
+        {
+            slice.processed = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod batch_scheduler_tests {
+    use libp2p::PeerId;
+
+    use super::SliceTracker;
+
+    #[tokio::test]
+    async fn simple_scheduling() {
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+        let num_slices = 7;
+
+        let mut tracker = SliceTracker::new(num_slices);
+
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 4);
+        assert_eq!(tracker.next(&peer_2), 5);
+        assert_eq!(tracker.next(&peer_1), 6);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_1), 0);
+    }
+
+    #[tokio::test]
+    async fn fast_slow_scheduling() {
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+        let num_slices = 7;
+
+        let mut tracker = SliceTracker::new(num_slices);
+
+        // Round 0
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_1), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 4);
+        assert_eq!(tracker.next(&peer_1), 5);
+        assert_eq!(tracker.next(&peer_1), 6);
+        // Round 1
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_1), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        let slice = tracker.next(&peer_2);
+        let mut left_slices = vec![4, 5, 6];
+        assert!(left_slices.contains(&slice));
+        left_slices.retain(|f| f != &slice);
+        assert!(left_slices.contains(&tracker.next(&peer_1)));
+        assert!(left_slices.contains(&tracker.next(&peer_1)));
+        // Round 2
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.rounds, 2);
+    }
+
+    #[tokio::test]
+    async fn peer_removed_scheduling() {
+        let peer_1 = PeerId::random();
+        let peer_2 = PeerId::random();
+        let peer_3 = PeerId::random();
+        let num_slices = 7;
+
+        let mut tracker = SliceTracker::new(num_slices);
+
+        // Round 0
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 4);
+        assert_eq!(tracker.next(&peer_2), 5);
+        assert_eq!(tracker.next(&peer_1), 6);
+        tracker.remove_worker(&peer_1);
+        assert_eq!(tracker.next(&peer_3), 6);
+        // Round 1
+        assert_eq!(tracker.next(&peer_2), 0);
+        assert_eq!(tracker.next(&peer_3), 2);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_3), 4);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_3), 6);
+        assert_eq!(tracker.next(&peer_2), 5);
     }
 }

--- a/crates/worker/src/connector/mod.rs
+++ b/crates/worker/src/connector/mod.rs
@@ -490,7 +490,7 @@ where
                             let item = ReadItem {
                                 meta: ItemMeta {
                                     kind: "peer",
-                                    name: data_provider.to_string(),
+                                    name: index.to_string(),
                                 },
                                 reader: Box::pin(stream),
                             };


### PR DESCRIPTION
This PR introduce the capabilities for the scheduler to track and asign more than one Slice and the worker to continuesly request new slices.

It introduces a `trust_remote_code` flag that is passed to transformers on model loading to allow custom models. While using custom models introduces a security risk. The owner of an executor can decide if its ok to run such models.

We should refactor this once we have the full capabilities refactoring. This is tracked in #123
