### PR TITLE
Merge command line arguments with defaults

### DIFF
--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     /// trusted by all peers.
     ///
     /// SECURITY: Use certificates from a recognized CA or internal PKI for production deployments.
-    pub cert_pem: PathBuf,
+    cert_pem: PathBuf,
 
     /// Path to the private key PEM file.
     ///
@@ -35,13 +35,13 @@ pub struct Config {
     /// * Never commit to version control
     /// * Store securely using secrets management systems in production
     /// * Keep backups in secure, encrypted storage
-    pub key_pem: PathBuf,
+    key_pem: PathBuf,
 
     /// Path to the trust chain PEM file (CA bundle).
     ///
     /// Contains root and intermediate certificates trusted by this data node. Peers presenting
     /// certificates signed by these CAs will be accepted for network connections.
-    pub trust_pem: PathBuf,
+    trust_pem: PathBuf,
 
     /// Path to certificate revocation list PEM (optional).
     ///
@@ -50,7 +50,7 @@ pub struct Config {
     ///
     /// SECURITY: Keep this updated with your certificate authority's latest CRL to maintain
     /// network security. Automate CRL updates in production environments.
-    pub crls_pem: Option<PathBuf>,
+    crls_pem: Option<PathBuf>,
 
     /// Gateway addresses to connect to (required for network entry).
     ///
@@ -62,7 +62,7 @@ pub struct Config {
     /// Examples:
     /// *  "/ip4/203.0.113.10/tcp/8080/"
     /// * "/dns4/gateway.hypha.example/tcp/443/"
-    pub gateway_addresses: Vec<Multiaddr>,
+    gateway_addresses: Vec<Multiaddr>,
 
     /// Network addresses to listen on for incoming connections.
     ///
@@ -71,7 +71,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/0.0.0.0/tcp/0" - TCP on all interfaces, OS-assigned port
     /// * "/ip4/0.0.0.0/udp/0/quic-v1" - QUIC on all interfaces, OS-assigned port
-    pub listen_addresses: Vec<Multiaddr>,
+    listen_addresses: Vec<Multiaddr>,
 
     /// Path to the dataset directory.
     ///
@@ -95,7 +95,7 @@ pub struct Config {
     /// ```
     ///
     /// The directory is scanned at startup and dataset metadata is announced via DHT.
-    pub dataset_path: PathBuf,
+    dataset_path: PathBuf,
 
     /// CIDR address filters for DHT routing table management.
     ///
@@ -108,7 +108,7 @@ pub struct Config {
     ///
     /// NOTE: This only affects DHT address filtering, not direct peer connections.
     #[serde(default = "reserved_cidrs")]
-    pub exclude_cidr: Vec<IpNet>,
+    exclude_cidr: Vec<IpNet>,
 
     /// OpenTelemetry Protocol (OTLP) endpoint for exporting telemetry data.
     ///
@@ -117,7 +117,7 @@ pub struct Config {
     ///
     /// If unset, telemetry export is disabled (local logging only).
     #[serde(alias = "exporter_otlp_endpoint")]
-    pub telemetry_endpoint: Option<Endpoint>,
+    telemetry_endpoint: Option<Endpoint>,
 
     /// Resource attributes included in all telemetry data.
     ///
@@ -134,7 +134,7 @@ pub struct Config {
     ///
     /// These attributes appear in all exported metrics, traces, and logs.
     #[serde(alias = "resource_attributes")]
-    pub telemetry_attributes: Option<Attributes>,
+    telemetry_attributes: Option<Attributes>,
 
     /// HTTP/gRPC headers for OTLP endpoint authentication.
     ///
@@ -145,13 +145,13 @@ pub struct Config {
     /// SECURITY: Protect these credentials. Use environment variables or secrets management
     /// instead of hardcoding in config files. Never commit credentials to version control.
     #[serde(alias = "exporter_otlp_headers")]
-    pub telemetry_headers: Option<Headers>,
+    telemetry_headers: Option<Headers>,
 
     /// Protocol for OTLP telemetry endpoint communication.
     ///
     /// Choose based on your collector's supported protocols.
     #[serde(alias = "exporter_otlp_protocol")]
-    pub telemetry_protocol: Option<Protocol>,
+    telemetry_protocol: Option<Protocol>,
 
     /// Trace sampling strategy to control volume and costs.
     ///
@@ -164,7 +164,7 @@ pub struct Config {
     /// RECOMMENDATION: Use "traceidratio" with sample_ratio for production to balance
     /// observability with costs. Start with 0.1 (10%) and adjust based on data volume.
     #[serde(alias = "traces_sampler")]
-    pub telemetry_sampler: Option<SamplerKind>,
+    telemetry_sampler: Option<SamplerKind>,
 
     /// Sampling probability for ratio-based trace samplers.
     ///
@@ -178,7 +178,7 @@ pub struct Config {
     /// NOTE: Lower ratios reduce telemetry costs while maintaining statistical
     /// significance. For high-throughput data nodes, 0.01-0.1 is probably sufficient.
     #[serde(alias = "traces_sampler_arg")]
-    pub telemetry_sample_ratio: Option<f64>,
+    telemetry_sample_ratio: Option<f64>,
 }
 
 impl Default for Config {

--- a/crates/gateway/src/bin/hypha-gateway.rs
+++ b/crates/gateway/src/bin/hypha-gateway.rs
@@ -1,6 +1,5 @@
 use std::{
     fs,
-    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -9,7 +8,10 @@ use std::{
 };
 
 use clap::Parser;
-use figment::providers::{Env, Format, Serialized, Toml};
+use figment::{
+    providers::{Env, Format, Serialized, Toml},
+    value::Map,
+};
 use futures_util::future::join_all;
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_gateway::{config::Config, network::Network};
@@ -159,19 +161,21 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {
         Commands::Init { output, name } => {
-            let mut config = Config::default();
-            let mut output = output.clone();
+            let mut config_builder =
+                builder::<Config>().with_provider(Serialized::defaults(&Config::default()));
 
             // Override config fields if values are provided.
             if let Some(name) = name {
-                config.cert_pem = PathBuf::from(format!("{name}-cert.pem"));
-                config.key_pem = PathBuf::from(format!("{name}-key.pem"));
-                config.trust_pem = PathBuf::from(format!("{name}-trust.pem"));
-
-                output.set_file_name(format!("{name}-config.toml"));
+                config_builder = config_builder.with_provider(Serialized::defaults(Map::from([
+                    ("cert_pem", format!("{name}-cert.pem")),
+                    ("key_pem", format!("{name}-key.pem")),
+                    ("trust_pem", format!("{name}-trust.pem")),
+                ])));
             }
 
-            fs::write(&output, &to_toml(&config).into_diagnostic()?).into_diagnostic()?;
+            let config = config_builder.build()?.validate()?;
+
+            fs::write(output, &to_toml(&config.config).into_diagnostic()?).into_diagnostic()?;
 
             println!("Configuration written to: {output:?}");
             Ok(())

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
     ///
     /// SECURITY: Use certificates from a recognized CA or internal PKI for production deployments.
     /// For testing, self-signed certificates are acceptable but must be distributed to all peers.
-    pub cert_pem: PathBuf,
+    cert_pem: PathBuf,
 
     /// Path to the private key PEM file.
     ///
@@ -35,7 +35,7 @@ pub struct Config {
     ///   * Never commit to version control
     ///   * Store securely using secrets management systems in production
     ///   * Keep backups in secure, encrypted storage
-    pub key_pem: PathBuf,
+    key_pem: PathBuf,
 
     /// Path to the trust chain PEM file (CA bundle).
     ///
@@ -44,7 +44,7 @@ pub struct Config {
     ///
     /// For self-signed deployments, include all peer certificates. For production, use
     /// certificates from your organization's PKI or a recognized CA.
-    pub trust_pem: PathBuf,
+    trust_pem: PathBuf,
 
     /// Path to certificate revocation list PEM (optional).
     ///
@@ -53,7 +53,7 @@ pub struct Config {
     ///
     /// SECURITY: Keep this updated with your certificate authority's latest CRL to maintain
     /// network security. Automate CRL updates in production environments.
-    pub crls_pem: Option<PathBuf>,
+    crls_pem: Option<PathBuf>,
 
     /// Network addresses to listen on for incoming connections.
     ///
@@ -64,7 +64,7 @@ pub struct Config {
     /// * "/ip4/0.0.0.0/tcp/8080" - TCP on all interfaces
     /// * "/ip4/0.0.0.0/udp/8080/quic-v1" - QUIC on all interfaces
     /// * "/ip6/::/tcp/8080" - TCP on all IPv6 interfaces
-    pub listen_addresses: Vec<Multiaddr>,
+    listen_addresses: Vec<Multiaddr>,
 
     /// External addresses to advertise for peer discovery.
     ///
@@ -80,7 +80,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/203.0.113.10/tcp/8080" - Public IPv4 address
     /// * "/dns4/gateway.example.com/tcp/8080" - DNS name with public IP
-    pub external_addresses: Vec<Multiaddr>,
+    external_addresses: Vec<Multiaddr>,
 
     /// OpenTelemetry Protocol (OTLP) endpoint for exporting telemetry data.
     ///
@@ -89,7 +89,7 @@ pub struct Config {
     ///
     /// If unset, telemetry export is disabled (local logging only).
     #[serde(alias = "exporter_otlp_endpoint")]
-    pub telemetry_endpoint: Option<Endpoint>,
+    telemetry_endpoint: Option<Endpoint>,
 
     /// Resource attributes included in all telemetry data.
     ///
@@ -106,7 +106,7 @@ pub struct Config {
     ///
     /// These attributes appear in all exported metrics, traces, and logs.
     #[serde(alias = "resource_attributes")]
-    pub telemetry_attributes: Option<Attributes>,
+    telemetry_attributes: Option<Attributes>,
 
     /// HTTP/gRPC headers for OTLP endpoint authentication.
     ///
@@ -117,13 +117,13 @@ pub struct Config {
     /// SECURITY: Protect these credentials. Use environment variables or secrets management
     /// instead of hardcoding in config files. Never commit credentials to version control.
     #[serde(alias = "exporter_otlp_headers")]
-    pub telemetry_headers: Option<Headers>,
+    telemetry_headers: Option<Headers>,
 
     /// Protocol for OTLP telemetry endpoint communication.
     ///
     /// Choose based on your collector's supported protocols.
     #[serde(alias = "exporter_otlp_protocol")]
-    pub telemetry_protocol: Option<Protocol>,
+    telemetry_protocol: Option<Protocol>,
 
     /// Trace sampling strategy to control volume and costs.
     ///
@@ -136,7 +136,7 @@ pub struct Config {
     /// RECOMMENDATION: Use "traceidratio" with sample_ratio for production to balance
     /// observability with costs. Start with 0.1 (10%) and adjust based on traffic volume.
     #[serde(alias = "traces_sampler")]
-    pub telemetry_sampler: Option<SamplerKind>,
+    telemetry_sampler: Option<SamplerKind>,
 
     /// Sampling probability for ratio-based trace samplers.
     ///
@@ -150,7 +150,7 @@ pub struct Config {
     /// NOTE: Lower ratios reduce telemetry costs while maintaining statistical
     /// significance. For high-traffic gateways, 0.01-0.1 is typically sufficient.
     #[serde(alias = "traces_sampler_arg")]
-    pub telemetry_sample_ratio: Option<f64>,
+    telemetry_sample_ratio: Option<f64>,
 
     /// CIDR address filters for DHT routing table management.
     ///
@@ -166,7 +166,7 @@ pub struct Config {
     ///
     /// Note: This only affects DHT address filtering, not direct peer connections.
     #[serde(default = "reserved_cidrs")]
-    pub exclude_cidr: Vec<IpNet>,
+    exclude_cidr: Vec<IpNet>,
 }
 
 impl Default for Config {

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -1,9 +1,12 @@
 //! Scheduler binary.
 
-use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use std::{fs, sync::Arc, time::Duration};
 
 use clap::Parser;
-use figment::providers::{Env, Format, Serialized, Toml};
+use figment::{
+    providers::{Env, Format, Serialized, Toml},
+    value::Map,
+};
 use futures_util::future::{join_all, select_all};
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_messages::{
@@ -31,6 +34,7 @@ use hypha_scheduler::{
 use hypha_telemetry as telemetry;
 use libp2p::{Multiaddr, PeerId, multiaddr::Protocol};
 use miette::{IntoDiagnostic, Result};
+use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -468,23 +472,27 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {
         Commands::Init { output, name, job } => {
-            let mut config = Config::default();
-            let mut output = output.clone();
+            let mut config_builder =
+                builder::<Config>().with_provider(Serialized::defaults(&Config::default()));
 
             // Override config fields if values are provided.
             if let Some(name) = name {
-                config.cert_pem = PathBuf::from(format!("{name}-cert.pem"));
-                config.key_pem = PathBuf::from(format!("{name}-key.pem"));
-                config.trust_pem = PathBuf::from(format!("{name}-trust.pem"));
+                config_builder = config_builder.with_provider(Serialized::defaults(Map::from([
+                    ("cert_pem", format!("{name}-cert.pem")),
+                    ("key_pem", format!("{name}-key.pem")),
+                    ("trust_pem", format!("{name}-trust.pem")),
+                ])));
+            }
+            if let Some(job_json) = job {
+                let job: Value = serde_json::from_str(job_json).into_diagnostic()?;
 
-                output.set_file_name(format!("{name}-config.toml"));
+                config_builder =
+                    config_builder.with_provider(Serialized::default("scheduler", job));
             }
 
-            if let Some(job) = job {
-                config.scheduler = serde_json::from_str(job).into_diagnostic()?;
-            }
+            let config = config_builder.build()?.validate()?;
 
-            fs::write(&output, &to_toml(&config)?).into_diagnostic()?;
+            fs::write(output, &to_toml(&config.config)?).into_diagnostic()?;
 
             println!("Configuration written to: {output:?}");
             Ok(())

--- a/crates/scheduler/src/config.rs
+++ b/crates/scheduler/src/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
     /// trusted by all peers.
     ///
     /// SECURITY: Use certificates from a recognized CA or internal PKI for production deployments.
-    pub cert_pem: PathBuf,
+    cert_pem: PathBuf,
 
     /// Path to the private key PEM file.
     ///
@@ -37,13 +37,13 @@ pub struct Config {
     ///   * Never commit to version control
     ///   * Store securely using secrets management systems in production
     ///   * Keep backups in secure, encrypted storage
-    pub key_pem: PathBuf,
+    key_pem: PathBuf,
 
     /// Path to the trust chain PEM file (CA bundle).
     ///
     /// Contains root and intermediate certificates trusted by this scheduler. Peers presenting
     /// certificates signed by these CAs will be accepted for network connections.
-    pub trust_pem: PathBuf,
+    trust_pem: PathBuf,
 
     /// Path to certificate revocation list PEM (optional).
     ///
@@ -52,7 +52,7 @@ pub struct Config {
     ///
     /// SECURITY: Keep this updated with your certificate authority's latest CRL to maintain
     /// network security. Automate CRL updates in production environments.
-    pub crls_pem: Option<PathBuf>,
+    crls_pem: Option<PathBuf>,
 
     /// Gateway addresses to connect to (required for network entry).
     ///
@@ -64,7 +64,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/203.0.113.10/tcp/8080/"
     /// * "/dns4/gateway.hypha.example/tcp/443/"
-    pub gateway_addresses: Vec<Multiaddr>,
+    gateway_addresses: Vec<Multiaddr>,
 
     /// Network addresses to listen on for incoming connections.
     ///
@@ -73,7 +73,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/0.0.0.0/tcp/0" - TCP on all interfaces, OS-assigned port
     /// * "/ip4/0.0.0.0/udp/0/quic-v1" - QUIC on all interfaces, OS-assigned port
-    pub listen_addresses: Vec<Multiaddr>,
+    listen_addresses: Vec<Multiaddr>,
 
     /// External addresses to advertise for peer discovery (optional).
     ///
@@ -83,7 +83,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/203.0.113.20/tcp/9090"
     /// * "/dns4/scheduler.example.com/tcp/9090"
-    pub external_addresses: Vec<Multiaddr>,
+    external_addresses: Vec<Multiaddr>,
 
     /// CIDR address filters for DHT routing table management.
     ///
@@ -96,7 +96,7 @@ pub struct Config {
     ///
     /// NOTE: This only affects DHT address filtering, not direct peer connections.
     #[serde(default = "reserved_cidrs")]
-    pub exclude_cidr: Vec<IpNet>,
+    exclude_cidr: Vec<IpNet>,
 
     /// Enable listening via relay circuit through the gateway.
     ///
@@ -106,7 +106,7 @@ pub struct Config {
     ///
     /// RECOMMENDATION: Keep enabled (true) unless the scheduler has public IP and external
     /// addresses configured for direct connectivity.
-    pub relay_circuit: bool,
+    relay_circuit: bool,
 
     /// OpenTelemetry Protocol (OTLP) endpoint for exporting telemetry data.
     ///
@@ -115,7 +115,7 @@ pub struct Config {
     ///
     /// If unset, telemetry export is disabled (local logging only).
     #[serde(alias = "exporter_otlp_endpoint")]
-    pub telemetry_endpoint: Option<Endpoint>,
+    telemetry_endpoint: Option<Endpoint>,
 
     /// Resource attributes included in all telemetry data.
     ///
@@ -131,7 +131,7 @@ pub struct Config {
     ///
     /// These attributes appear in all exported metrics, traces, and logs.
     #[serde(alias = "resource_attributes")]
-    pub telemetry_attributes: Option<Attributes>,
+    telemetry_attributes: Option<Attributes>,
 
     /// HTTP/gRPC headers for OTLP endpoint authentication.
     ///
@@ -142,13 +142,13 @@ pub struct Config {
     /// SECURITY: Protect these credentials. Use environment variables or secrets management
     /// instead of hardcoding in config files. Never commit credentials to version control.
     #[serde(alias = "exporter_otlp_headers")]
-    pub telemetry_headers: Option<Headers>,
+    telemetry_headers: Option<Headers>,
 
     /// Protocol for OTLP telemetry endpoint communication.
     ///
     /// Choose based on your collector's supported protocols.
     #[serde(alias = "exporter_otlp_protocol")]
-    pub telemetry_protocol: Option<Protocol>,
+    telemetry_protocol: Option<Protocol>,
 
     /// Trace sampling strategy to control volume and costs.
     ///
@@ -161,7 +161,7 @@ pub struct Config {
     /// RECOMMENDATION: Use "traceidratio" with sample_ratio for production to balance
     /// observability with costs. Start with 0.1 (10%) and adjust based on job volume.
     #[serde(alias = "traces_sampler")]
-    pub telemetry_sampler: Option<SamplerKind>,
+    telemetry_sampler: Option<SamplerKind>,
 
     /// Sampling probability for ratio-based trace samplers.
     ///
@@ -175,7 +175,7 @@ pub struct Config {
     /// NOTE: Lower ratios reduce telemetry costs while maintaining statistical
     /// significance. For high-volume schedulers, 0.01-0.1 is probably sufficient.
     #[serde(alias = "traces_sampler_arg")]
-    pub telemetry_sample_ratio: Option<f64>,
+    telemetry_sample_ratio: Option<f64>,
 
     /// AIM relay server address for real-time training metrics (optional).
     ///
@@ -183,13 +183,13 @@ pub struct Config {
     /// monitoring job progress and visualizing training curves.
     ///
     /// Example: "0.0.0.0:61000"
-    pub status_bridge: Option<String>,
+    status_bridge: Option<String>,
 
     /// Scheduler-specific configuration for job orchestration.
     ///
     /// Contains settings for resource allocation, job scheduling policies, and worker
     /// management strategies.
-    pub scheduler: SchedulerConfig,
+    scheduler: SchedulerConfig,
 }
 
 impl Default for Config {

--- a/crates/scheduler/src/scheduler_config.rs
+++ b/crates/scheduler/src/scheduler_config.rs
@@ -36,20 +36,25 @@ impl Default for DiLoCo {
     fn default() -> Self {
         Self {
             model: ModelSource {
-                repository: "l45k/Resnet50".to_string(),
+                repository: "hypha-space/lenet".to_string(),
                 revision: None,
-                filenames: vec!["config.json".to_string(), "model.safetensors".to_string()],
-                token: Some("hf_1234token".to_string()),
+                filenames: vec![
+                    "config.json".to_string(),
+                    "model.safetensors".to_string(),
+                    "configuration_lenet.py".to_string(),
+                    "modeling_lenet.py".to_string(),
+                ],
+                token: None,
                 model_type: ModelType::VisionClassification,
             },
             preprocessor: Some(PreprocessorSource {
-                repository: "l45k/Resnet50".to_string(),
+                repository: "hypha-space/lenet".to_string(),
                 revision: None,
                 filenames: vec!["preprocessor_config.json".to_string()],
-                token: Some("hf_1234token".to_string()),
+                token: None,
             }),
             dataset: DataNodeSource {
-                dataset: "imagnet".to_string(),
+                dataset: "mnist".to_string(),
             },
             inner_optimizer: Adam {
                 learning_rate: 1e-3,

--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -149,7 +149,7 @@ pub struct Config {
     /// trusted by all peers.
     ///
     /// SECURITY: Use certificates from a recognized CA or internal PKI for production deployments.
-    pub cert_pem: PathBuf,
+    cert_pem: PathBuf,
 
     /// Path to the private key PEM file.
     ///
@@ -160,13 +160,13 @@ pub struct Config {
     ///   * Never commit to version control
     ///   * Store securely using secrets management systems in production
     ///   * Keep backups in secure, encrypted storage
-    pub key_pem: PathBuf,
+    key_pem: PathBuf,
 
     /// Path to the trust chain PEM file (CA bundle).
     ///
     /// Contains root and intermediate certificates trusted by this worker. Peers presenting
     /// certificates signed by these CAs will be accepted for network connections.
-    pub trust_pem: PathBuf,
+    trust_pem: PathBuf,
 
     /// Path to certificate revocation list PEM (optional).
     ///
@@ -175,7 +175,7 @@ pub struct Config {
     ///
     /// SECURITY: Keep this updated with your certificate authority's latest CRL to maintain
     /// network security. Automate CRL updates in production environments.
-    pub crls_pem: Option<PathBuf>,
+    crls_pem: Option<PathBuf>,
 
     /// Gateway addresses to connect to (required for network entry).
     ///
@@ -187,7 +187,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/203.0.113.10/tcp/8080/"
     /// * "/dns4/gateway.hypha.example/tcp/443/"
-    pub gateway_addresses: Vec<Multiaddr>,
+    gateway_addresses: Vec<Multiaddr>,
 
     /// Network addresses to listen on for incoming connections.
     ///
@@ -196,7 +196,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/0.0.0.0/tcp/0" - TCP on all interfaces, OS-assigned port
     /// * "/ip4/0.0.0.0/udp/0/quic-v1" - QUIC on all interfaces, OS-assigned port
-    pub listen_addresses: Vec<Multiaddr>,
+    listen_addresses: Vec<Multiaddr>,
 
     /// External addresses to advertise for peer discovery (optional).
     ///
@@ -206,7 +206,7 @@ pub struct Config {
     /// Examples:
     /// * "/ip4/203.0.113.30/tcp/9091"
     /// * "/dns4/worker.example.com/tcp/9091"
-    pub external_addresses: Vec<Multiaddr>,
+    external_addresses: Vec<Multiaddr>,
 
     /// CIDR address filters for DHT routing table management.
     ///
@@ -219,7 +219,7 @@ pub struct Config {
     ///
     /// NOTE: This only affects DHT address filtering, not direct peer connections.
     #[serde(default = "reserved_cidrs")]
-    pub exclude_cidr: Vec<IpNet>,
+    exclude_cidr: Vec<IpNet>,
 
     /// Enable listening via relay circuit through the gateway.
     ///
@@ -229,7 +229,7 @@ pub struct Config {
     ///
     /// RECOMMENDATION: Keep enabled (true) unless the worker has public IP and external
     /// addresses configured for direct connectivity.
-    pub relay_circuit: bool,
+    relay_circuit: bool,
 
     /// Base directory for per-job working directories.
     ///
@@ -244,13 +244,13 @@ pub struct Config {
     ///
     /// Jobs clean up their directories on successful completion, but failures may leave
     /// artifacts for debugging.
-    pub work_dir: PathBuf,
+    work_dir: PathBuf,
 
     /// Available compute resources advertised to schedulers.
     ///
     /// Accurately configure resources to enable proper job allocation. Resources are
     /// reserved during job allocation and jobs exceeding available resources will be rejected.
-    pub resources: ResourceConfig,
+    resources: ResourceConfig,
 
     /// Available executors for different job types.
     ///
@@ -258,7 +258,7 @@ pub struct Config {
     /// executors for training, inference, parameter serving, or custom workloads.
     ///
     /// Workers with no executors configured cannot accept jobs.
-    pub executors: Vec<ExecutorConfig>,
+    executors: Vec<ExecutorConfig>,
 
     /// OpenTelemetry Protocol (OTLP) endpoint for exporting telemetry data.
     ///
@@ -267,7 +267,7 @@ pub struct Config {
     ///
     /// If unset, telemetry export is disabled (local logging only).
     #[serde(alias = "exporter_otlp_endpoint")]
-    pub telemetry_endpoint: Option<Endpoint>,
+    telemetry_endpoint: Option<Endpoint>,
 
     /// Resource attributes included in all telemetry data.
     ///
@@ -284,7 +284,7 @@ pub struct Config {
     ///
     /// These attributes appear in all exported metrics, traces, and logs.
     #[serde(alias = "resource_attributes")]
-    pub telemetry_attributes: Option<Attributes>,
+    telemetry_attributes: Option<Attributes>,
 
     /// HTTP/gRPC headers for OTLP endpoint authentication.
     ///
@@ -295,13 +295,13 @@ pub struct Config {
     /// SECURITY: Protect these credentials. Use environment variables or secrets management
     /// instead of hardcoding in config files. Never commit credentials to version control.
     #[serde(alias = "exporter_otlp_headers")]
-    pub telemetry_headers: Option<Headers>,
+    telemetry_headers: Option<Headers>,
 
     /// Protocol for OTLP telemetry endpoint communication.
     ///
     /// Choose based on your collector's supported protocols.
     #[serde(alias = "exporter_otlp_protocol")]
-    pub telemetry_protocol: Option<Protocol>,
+    telemetry_protocol: Option<Protocol>,
 
     /// Trace sampling strategy to control volume and costs.
     ///
@@ -314,7 +314,7 @@ pub struct Config {
     /// RECOMMENDATION: Use "traceidratio" with sample_ratio for production to balance
     /// observability with costs. Start with 0.1 (10%) and adjust based on job volume.
     #[serde(alias = "traces_sampler")]
-    pub telemetry_sampler: Option<SamplerKind>,
+    telemetry_sampler: Option<SamplerKind>,
 
     /// Sampling probability for ratio-based trace samplers.
     ///
@@ -328,7 +328,7 @@ pub struct Config {
     /// NOTE: Lower ratios reduce telemetry costs while maintaining statistical
     /// significance. For high-throughput workers, 0.01-0.1 is probably sufficient.
     #[serde(alias = "traces_sampler_arg")]
-    pub telemetry_sample_ratio: Option<f64>,
+    telemetry_sample_ratio: Option<f64>,
 }
 
 impl Default for Config {


### PR DESCRIPTION
Uses 'figment' to merge command line argument overrides in the 'init'
subcommand with our default configuration. Notably this allows to
provide a subset of a 'SchedulerConfig' instead of a complete one when
using the '--job' argument.

For example one can now run
```
hypha-scheduler init -j '{"job": {"model": {"token": "my_token"}}}'
```

to initialize a configuration with the HF token already set.