### PR TITLE
Log at 'INFO' level by default

### DIFF
--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -21,6 +21,7 @@ use tokio::{
     fs,
     signal::unix::{SignalKind, signal},
 };
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt,
 };
@@ -60,7 +61,13 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     telemetry::metrics::global::set_provider(metrics.provider());
 
     Registry::default()
-        .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env()))
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            ),
+        )
         .with(tracing.layer())
         .with(logging.layer())
         .init();

--- a/crates/gateway/src/bin/hypha-gateway.rs
+++ b/crates/gateway/src/bin/hypha-gateway.rs
@@ -24,6 +24,7 @@ use hypha_telemetry as telemetry;
 use libp2p::Multiaddr;
 use miette::{IntoDiagnostic, Result};
 use tokio::signal::unix::{SignalKind, signal};
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt,
 };
@@ -63,7 +64,13 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     telemetry::metrics::global::set_provider(metrics.provider());
 
     Registry::default()
-        .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env()))
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            ),
+        )
         .with(tracing.layer())
         .with(logging.layer())
         .init();

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -38,6 +38,7 @@ use serde_json::Value;
 use tokio::{sync::Mutex, time::sleep};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt,
 };
@@ -81,7 +82,13 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     telemetry::metrics::global::set_provider(metrics.provider());
 
     Registry::default()
-        .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env()))
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            ),
+        )
         .with(tracing.layer())
         .with(logging.layer())
         .init();

--- a/crates/worker/src/bin/hypha-worker.rs
+++ b/crates/worker/src/bin/hypha-worker.rs
@@ -30,6 +30,7 @@ use libp2p::{Multiaddr, multiaddr::Protocol};
 use miette::{IntoDiagnostic, Result};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio_util::sync::CancellationToken;
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, layer::SubscriberExt, util::SubscriberInitExt,
 };
@@ -69,7 +70,13 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     telemetry::metrics::global::set_provider(metrics.provider());
 
     Registry::default()
-        .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env()))
+        .with(
+            tracing_subscriber::fmt::layer().with_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            ),
+        )
         .with(tracing.layer())
         .with(logging.layer())
         .init();


### PR DESCRIPTION
Hypha is logging high-level status information at the `INFO` level. It's useful for users to see these messages by default to follow Hypha's progress.