### PR TITLE
docs(release): add installer to release notes

### DIFF
--- a/.github/release-notes-template.hbs
+++ b/.github/release-notes-template.hbs
@@ -1,0 +1,21 @@
+{{> header}}
+
+{{#each commitGroups}}
+{{#each commits}}
+{{> commit root=@root}}
+{{/each}}
+{{/each}}
+
+{{> footer}}
+
+---
+
+## Installation
+
+Use the standalone installer script to download and install the Hypha v{{nextRelease.version}} binaries. Use `curl` to download the script and execute it with sh:
+
+```sh
+curl -fsSL https://github.com/hypha-space/hypha/releases/download/v{{nextRelease.version}}/install.sh | sh
+```
+
+For alternative installation methods (GitHub releases, Cargo), see the [Installation Guide](https://github.com/hypha-space/hypha/blob/alpha/docs/installation.md).

--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,9 @@ branches:
     prerelease: true
 plugins:
   - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/release-notes-generator"
+    - writerOpts:
+        mainTemplate: ".github/release-notes-template.hbs"
   - - "@semantic-release/github"
     - assets:
         # artifacts will be pushed to artifacts/**/* by the release workflow


### PR DESCRIPTION
Add a custom release notes template that includes documentation for the standalone installer with automatic version substitution. The template appends installation instructions to each GitHub release, making it easier for users to install the specific version.