### PR TITLE
feat: training round control

### DIFF
--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -277,9 +277,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         && allocated_parameter_servers.len() == 1
     {
         let job_id = Uuid::new_v4();
-        let batch_sizes = [22, 12];
-        let samples_per_update = 1200;
-        let diloco_rounds = 100;
+        let batch_sizes = [40, 60];
 
         let worker1 = &allocated_workers[0];
         let worker2 = &allocated_workers[1];
@@ -292,8 +290,8 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         // TODO compute true batch sizes
         let run_tracker = Arc::new(Mutex::new(ProgressTracker::<RunningMean>::new(
             allocated_parameter_servers[0].peer_id(),
-            samples_per_update,
-            diloco_rounds,
+            diloco_config.rounds.avg_samples_between_updates,
+            diloco_config.rounds.update_rounds,
         )));
         run_tracker
             .lock()
@@ -331,7 +329,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
                         ),
                         results: Receive::peers(vec![parameter_server.peer_id()]),
                         optimizer: diloco_config.inner_optimizer.clone(),
-                        batch_size: 40,
+                        batch_size: batch_sizes[0],
                         preprocessor: diloco_config.preprocessor.clone().map(|p| p.into()),
                         scheduler: None,
                     })
@@ -356,7 +354,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
                         ),
                         results: Receive::peers(vec![parameter_server.peer_id()]),
                         optimizer: diloco_config.inner_optimizer.clone(),
-                        batch_size: 60,
+                        batch_size: batch_sizes[1],
                         preprocessor: diloco_config.preprocessor.clone().map(|p| p.into()),
                         scheduler: None,
                     })

--- a/crates/scheduler/src/scheduler_config.rs
+++ b/crates/scheduler/src/scheduler_config.rs
@@ -25,6 +25,7 @@ pub struct DiLoCo {
     pub model: ModelSource,
     pub preprocessor: Option<PreprocessorSource>,
     pub dataset: DataNodeSource,
+    pub rounds: DiLoCoRounds,
     #[serde(rename = "inner_optimizer")]
     pub inner_optimizer: Adam,
     #[serde(rename = "outer_optimizer")]
@@ -55,6 +56,10 @@ impl Default for DiLoCo {
             }),
             dataset: DataNodeSource {
                 dataset: "mnist".to_string(),
+            },
+            rounds: DiLoCoRounds {
+                update_rounds: 100,
+                avg_samples_between_updates: 1200,
             },
             inner_optimizer: Adam {
                 learning_rate: 1e-3,
@@ -138,6 +143,12 @@ pub struct PreprocessorSource {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DataNodeSource {
     pub dataset: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DiLoCoRounds {
+    pub avg_samples_between_updates: u32,
+    pub update_rounds: u32,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/executors/accelerate/src/hypha/accelerate_executor/training.py
+++ b/executors/accelerate/src/hypha/accelerate_executor/training.py
@@ -293,7 +293,7 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
                 session.send_status({"metrics": {"round": epoch_counter, "metrics": {"loss": float(np.mean(losses))}}})
                 epoch_counter += 1
 
-            print(f"Finished training of {epoch_counter - 1} epochs", flush=True)
+            print(f"Finished training of {epoch_counter} DiLoCo update rounds", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introducing parameters for number of inter DiLoCo update samples and number of updates during a training. This leaves it to the users to match the dataset size with the number of DiLoCo rounds and the effective number of epochs.

This closed #138
