### PR TITLE
feat(gateway): add support for connecting to other gateways

### DIFF
--- a/crates/gateway/src/bin/hypha-gateway.rs
+++ b/crates/gateway/src/bin/hypha-gateway.rs
@@ -130,6 +130,32 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     )
     .await;
 
+    // NOTE: Dial each gateway address (if any provided). The gateway attempts to connect
+    // to all addresses and succeeds if any are reachable. Empty gateway_addresses is valid.
+    let _ = join_all(
+        config
+            .gateway_addresses()
+            .iter()
+            .map(|address| {
+                let address = address.clone();
+                let network = network.clone();
+                async move {
+                    match network.dial(address.clone()).await {
+                        Ok(peer_id) => {
+                            tracing::info!(address=%address, peer_id=%peer_id, "Connected to gateway");
+                            Ok(peer_id)
+                        }
+                        Err(e) => {
+                            tracing::warn!(address=%address, error=%e, "Failed to connect to gateway");
+                            Err(e)
+                        }
+                    }
+                }
+            })
+            .collect::<Vec<_>>(),
+    )
+    .await;
+
     let mut sigterm = signal(SignalKind::terminate()).into_diagnostic()?;
 
     tokio::select! {

--- a/crates/gateway/src/cli.rs
+++ b/crates/gateway/src/cli.rs
@@ -75,6 +75,19 @@ pub enum Commands {
         #[serde(skip_serializing_if = "Option::is_none")]
         crls_pem: Option<PathBuf>,
 
+        /// Gateway addresses to connect to (repeatable, overrides config)
+        ///
+        /// Gateways provide network bootstrapping, DHT access, and relay functionality.
+        /// Must include the peer ID in the multiaddr.
+        ///
+        /// Examples:
+        ///   --gateway /ip4/203.0.113.10/tcp/8080/p2p/12D3KooWAbc...
+        ///   --gateway /dns4/gateway.hypha.example/tcp/443/p2p/12D3KooWAbc...
+        /// Required: connect to at least one gateway.
+        #[arg(long("gateway"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
         /// Addresses to listen on (repeatable, overrides config)
         ///
         /// Where this gateway accepts incoming connections.
@@ -229,6 +242,19 @@ pub enum Commands {
         #[arg(long("crls"), verbatim_doc_comment)]
         #[serde(skip_serializing_if = "Option::is_none")]
         crls_pem: Option<PathBuf>,
+
+        /// Gateway addresses to connect to (repeatable, overrides config)
+        ///
+        /// Gateways provide network bootstrapping, DHT access, and relay functionality.
+        /// Must include the peer ID in the multiaddr.
+        ///
+        /// Examples:
+        ///   --gateway /ip4/203.0.113.10/tcp/8080/p2p/12D3KooWAbc...
+        ///   --gateway /dns4/gateway.hypha.example/tcp/443/p2p/12D3KooWAbc...
+        /// Required: connect to at least one gateway.
+        #[arg(long("gateway"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
 
         /// Addresses to listen on (repeatable, overrides config)
         ///


### PR DESCRIPTION
Gateways can now connect to other gateways for network entry, similar to how workers and schedulers connect. The gateway attempts to connect to all provided gateway addresses during startup. By deploying more than one gateway and connecting them together, one can improve the systems reliability.