### PR TITLE
fix: corrupted data caused by relayed streams

### DIFF
--- a/crates/data/src/network.rs
+++ b/crates/data/src/network.rs
@@ -21,7 +21,7 @@ use libp2p::{
     swarm::{NetworkBehaviour, SwarmEvent},
     tcp, tls, yamux,
 };
-use libp2p_stream as stream;
+use libp2p_stream::{self as stream, ConnectionPolicy};
 use tokio::sync::{SetOnce, mpsc};
 
 type HealthRequestHandlers = Vec<RequestHandler<health::Codec>>;
@@ -107,7 +107,7 @@ impl Network {
                     )),
                     relay_client,
                     dcutr: dcutr::Behaviour::new(key.public().to_peer_id()),
-                    stream: stream::Behaviour::new(),
+                    stream: stream::Behaviour::with_relay_policy(ConnectionPolicy::IgnoreRelayed),
                     kademlia: kad::Behaviour::new(
                         key.public().to_peer_id(),
                         kad::store::MemoryStore::new(key.public().to_peer_id()),

--- a/crates/worker/src/network.rs
+++ b/crates/worker/src/network.rs
@@ -34,7 +34,7 @@ use libp2p::{
     swarm::{NetworkBehaviour, SwarmEvent},
     tcp, tls, yamux,
 };
-use libp2p_stream as stream;
+use libp2p_stream::{self as stream, ConnectionPolicy};
 use tokio::sync::{SetOnce, mpsc};
 
 type HyphaRequestHandlers = Vec<RequestHandler<api::Codec>>;
@@ -141,7 +141,7 @@ impl Network {
                     )),
                     relay_client,
                     dcutr: dcutr::Behaviour::new(key.public().to_peer_id()),
-                    stream: stream::Behaviour::new(),
+                    stream: stream::Behaviour::with_relay_policy(ConnectionPolicy::IgnoreRelayed),
                     kademlia: kad::Behaviour::new(
                         key.public().to_peer_id(),
                         kad::store::MemoryStore::new(key.public().to_peer_id()),


### PR DESCRIPTION
Workers occasionally failed to load tensors from the data node with errors indicating corrupted or incomplete artifacts:

- data node: `Failed to serialize dataset: connection is closed`
- worker: `SafetensorError: incomplete metadata, file not fully covered`

Investigation of the gateway logs for the affected runs showed that the data stream was being relayed and the gateway closed the connection with `Max circuit bytes reached`. The number of bytes actually received by the worker (e.g. 106496 bytes) is within the 128 kibibyte circuit limit, explaining the truncated `.safetensors` file.

When opening a libp2p stream we would reuse any existing connection to the peer. If that connection was established via a relay for DCUtR, the same relayed connection was also used for the data stream. Large dataset/model transfers then traversed the relay and hit the circuit byte limit enforced by the gateway, resulting in a hard disconnect and truncated payloads.

Configure the `libp2p_stream` behaviour on both the data node and the worker to ignore relayed connections when opening streams forces stream establishment to pick a non-relayed connection (or fail), preventing large data transfers from being routed through a relay and truncated at the gateway’s circuit limit.