### PR TITLE
ci: add cargo-edit to Rust build action

### DIFF
--- a/.github/actions/build-rust/action.yaml
+++ b/.github/actions/build-rust/action.yaml
@@ -26,6 +26,10 @@ runs:
       run: rustup target add "${{ inputs.target }}"
       shell: bash
 
+    - name: Install cargo-edit
+      run: cargo install cargo-edit
+      shell: bash
+
     - name: Set version
       run: cargo set-version "${{ inputs.version }}"
       shell: bash


### PR DESCRIPTION
Revert cargo-edit install removal from action as CI fails otherwise.