### PR TITLE
feat: inspect CLI for debugging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,7 @@ jobs:
         with:
           version: ${{ needs.get-next-version.outputs.new-release-version }}
           target: ${{ matrix.target }}
-          binaries: "hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil"
+          binaries: "hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil hypha-inspect"
 
   github-release:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +681,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1717,7 +1736,7 @@ source = "git+https://github.com/huggingface/hf-hub.git?rev=94b8385#94b83854e026
 dependencies = [
  "dirs",
  "futures",
- "indicatif",
+ "indicatif 0.18.3",
  "libc",
  "log",
  "num_cpus",
@@ -1992,6 +2011,33 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "hypha-inspect"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "clap-markdown",
+ "console 0.15.11",
+ "documented",
+ "figment",
+ "futures-util",
+ "hypha-config",
+ "hypha-messages",
+ "hypha-network",
+ "indicatif 0.17.11",
+ "indoc",
+ "libp2p",
+ "miette",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-indicatif",
+ "tracing-subscriber",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -2325,14 +2371,28 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
+ "console 0.16.1",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
+ "vt100",
  "web-time",
 ]
 
@@ -3413,6 +3473,12 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -5294,6 +5360,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-indicatif"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d4e11e0e27acef25a47f27e9435355fecdc488867fa2bc90e75b0700d2823d"
+dependencies = [
+ "indicatif 0.18.3",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5522,6 +5600,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width 0.2.2",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -5765,6 +5864,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/worker",
     "crates/telemetry",
     "crates/resources",
+    "crates/inspect",
 ]
 default-members = [
     "crates/certutil",
@@ -19,7 +20,7 @@ default-members = [
     "crates/gateway",
     "crates/scheduler",
     "crates/worker",
-
+    "crates/inspect",
 ]
 
 [workspace.package]
@@ -37,6 +38,8 @@ figment = { version = "0.10", features = ["toml", "env"] }
 indoc = "2"
 futures-util = "0.3"
 http-body-util = "0.1.3"
+indicatif = "0.17.9"
+console = "0.15.8"
 hypha-config = { path = "crates/config" }
 hypha-leases = { path = "crates/leases" }
 hypha-messages = { path = "crates/messages" }
@@ -93,6 +96,7 @@ toml = { version = "0.9.5" }
 tower = { version = "0.5.2", features = ["util"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-indicatif = "0.3.6"
 utoipa = { version = "5.4.0", features = ["axum_extras", "url", "uuid"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 

--- a/crates/inspect/Cargo.toml
+++ b/crates/inspect/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "hypha-inspect"
+version.workspace = true
+publish.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+
+[dependencies]
+clap.workspace = true
+documented.workspace = true
+figment.workspace = true
+futures-util.workspace = true
+hypha-config.workspace = true
+hypha-messages.workspace = true
+hypha-network.workspace = true
+indicatif.workspace = true
+indoc.workspace = true
+libp2p.workspace = true
+miette.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-indicatif.workspace = true
+tracing-subscriber.workspace = true
+console.workspace = true
+x509-parser = "0.16"
+
+[build-dependencies]
+clap.workspace = true
+clap-markdown = "0.1.5"
+indoc.workspace = true
+libp2p.workspace = true
+serde.workspace = true

--- a/crates/inspect/build.rs
+++ b/crates/inspect/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}-cli.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(format!("{crate_name} CLI Reference"))
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/inspect/src/bin/hypha-inspect.rs
+++ b/crates/inspect/src/bin/hypha-inspect.rs
@@ -1,0 +1,287 @@
+use std::{fs, time::Duration};
+
+use clap::Parser;
+use console::style;
+use figment::providers::{Env, Format, Serialized, Toml};
+use futures_util::future::join_all;
+use hypha_config::{ConfigWithMetadataTLSExt, builder, to_toml};
+use hypha_inspect::{config::Config, network::Network};
+use hypha_messages::health;
+use hypha_network::{
+    cert, dial::DialInterface, kad::KademliaInterface,
+    request_response::RequestResponseInterfaceExt, swarm::SwarmDriver,
+};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use libp2p::Multiaddr;
+use miette::{IntoDiagnostic, Result};
+use tracing_indicatif::{
+    IndicatifLayer,
+    filter::{IndicatifFilter, hide_indicatif_span_fields},
+};
+use tracing_subscriber::{
+    EnvFilter, Layer, fmt::format::DefaultFields, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+#[path = "../cli.rs"]
+mod cli;
+use cli::{Cli, Commands};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Initialize tracing (simplified for CLI tool)
+    // Only initialize if NO OTHER subscriber is set (e.g. via env vars)
+    let indicatif_layer = IndicatifLayer::new()
+        .with_span_field_formatter(hide_indicatif_span_fields(DefaultFields::new()));
+    let indicatif_writer = indicatif_layer.get_stderr_writer();
+    let indicatif_layer = indicatif_layer.with_filter(IndicatifFilter::new(false));
+    if tracing_subscriber::registry()
+        .with(indicatif_layer)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(indicatif_writer)
+                .with_filter(EnvFilter::from_default_env()),
+        )
+        .try_init()
+        .is_err()
+    {
+        // Already initialized? Ignore.
+    }
+
+    match &cli.command {
+        args @ Commands::Probe {
+            config_file,
+            address,
+            timeout,
+            ..
+        } => {
+            let spinner = create_spinner();
+
+            spinner.set_message(format!("Dailing {address}..."));
+
+            let config = builder::<Config>()
+                .with_provider(Toml::file(config_file))
+                .with_provider(Env::prefixed("HYPHA_"))
+                .with_provider(Serialized::defaults(args))
+                .build()?
+                .validate()?;
+
+            let cert_chain = config.load_cert_chain()?;
+            let private_key = config.load_key()?;
+            let ca_certs = config.load_trust_chain()?;
+            let crls = config.load_crls()?;
+
+            let exclude_cidrs = hypha_network::reserved_cidrs();
+
+            let (network, network_driver) =
+                Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
+                    .into_diagnostic()?;
+
+            let network_driver_task = tokio::spawn(network_driver.run());
+
+            let addr: Multiaddr = address.parse().into_diagnostic()?;
+
+            tokio::time::timeout(Duration::from_millis(*timeout), {
+                let network = network.clone();
+
+                async move {
+                    let peer_id = network.dial(addr).await.into_diagnostic()?;
+
+                    spinner.set_message(format!("Health checking {peer_id}..."));
+
+                    let resp = network
+                        .request::<health::Codec>(peer_id, health::Request {})
+                        .await
+                        .into_diagnostic()?;
+
+                    spinner.finish_and_clear();
+
+                    println!(
+                        "{} {}",
+                        style("Address").bold(),
+                        style(format!("({address})")).dim()
+                    );
+                    println!("├─ {} {}", style("Peer ID:").bold(), style(peer_id));
+
+                    if resp.healthy {
+                        println!(
+                            "├─ {} {}",
+                            style("Status:").bold(),
+                            style("Healthy").green()
+                        );
+
+                        Ok(())
+                    } else {
+                        println!(
+                            "├─ {} {}",
+                            style("Status:").bold(),
+                            style("Unhealthy").red()
+                        );
+
+                        Err(miette::miette!("The peer is unhealthy"))
+                    }
+                }
+            })
+            .await
+            .into_diagnostic()??;
+
+            drop(network);
+            if !network_driver_task.is_finished() {
+                network_driver_task.abort();
+            }
+            Ok(())
+        }
+        args @ Commands::Lookup {
+            config_file,
+            peer_id,
+            ..
+        } => {
+            let peer_id = *peer_id;
+            let spinner = create_spinner();
+
+            spinner.set_message("Joining network...");
+
+            let config = builder::<Config>()
+                .with_provider(Toml::file(config_file))
+                .with_provider(Env::prefixed("HYPHA_"))
+                .with_provider(Serialized::defaults(args))
+                .build()?
+                .validate()?;
+
+            let cert_chain = config.load_cert_chain()?;
+            let private_key = config.load_key()?;
+            let ca_certs = config.load_trust_chain()?;
+            let crls = config.load_crls()?;
+
+            let exclude_cidrs = hypha_network::reserved_cidrs();
+
+            let (network, network_driver) =
+                Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
+                    .into_diagnostic()?;
+
+            let network_driver_task = tokio::spawn(network_driver.run());
+
+            let gateway_peer_ids: Vec<_> = join_all(
+                config
+                    .gateway_addresses()
+                    .iter()
+                    .map(|address| {
+                        let network = network.clone();
+                        async move { network.dial(address.clone()).await }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            .into_iter()
+            .filter_map(|result| result.ok())
+            .collect();
+
+            if gateway_peer_ids.is_empty() {
+                return Err(miette::miette!("Failed to connect to any gateway"));
+            }
+
+            tracing::info!(gateway_ids = ?gateway_peer_ids, "Connected to gateway(s)");
+
+            network.wait_for_bootstrap().await.into_diagnostic()?;
+
+            spinner.set_message(format!("Querying DHT for {peer_id}..."));
+
+            let closest_peers = network.get_closest_peers(peer_id).await.into_diagnostic()?;
+            if let Some(peer) = closest_peers
+                .iter()
+                .find(|peer| peer.peer_id == peer_id)
+                .cloned()
+            {
+                spinner.finish_and_clear();
+
+                println!(
+                    "{} {}",
+                    style("Peer").bold(),
+                    style(format!("({peer_id})")).dim()
+                );
+                for addr in peer.addrs {
+                    println!("├─ {} {}", style("Address:").dim(), style(addr));
+                }
+            } else {
+                return Err(miette::miette!("No peer with ID {} found.", peer_id));
+            }
+
+            drop(network);
+            if !network_driver_task.is_finished() {
+                network_driver_task.abort();
+            }
+            Ok(())
+        }
+        Commands::CertInfo { path } => {
+            let path = path.clone();
+            let spinner = create_spinner();
+            spinner.set_message(format!("Inspecting {}...", path.display()));
+            let content = fs::read(&path).into_diagnostic()?;
+
+            // Try private key first
+            if let Ok(key) = cert::load_private_key_from_pem(&content)
+                && let Ok(identity) = cert::identity_from_private_key(&key)
+            {
+                spinner.finish_and_clear();
+
+                let peer_id = identity.public().to_peer_id();
+                println!(
+                    "{} {}",
+                    style("Private Key").bold().on_red(),
+                    style(format!("({})", path.display())).dim()
+                );
+                println!("├─ {} {}", style("Peer ID:").bold(), style(peer_id).cyan());
+
+                return Ok(());
+            }
+
+            // Try certificate
+            let (_rem, pem) = x509_parser::pem::parse_x509_pem(&content).into_diagnostic()?;
+            let cert = pem.parse_x509().into_diagnostic()?;
+
+            let ed_key = libp2p::identity::ed25519::PublicKey::try_from_bytes(
+                &cert.tbs_certificate.subject_pki.subject_public_key.data,
+            )
+            .into_diagnostic()?;
+
+            let peer_id = libp2p::identity::PublicKey::from(ed_key).to_peer_id();
+            spinner.finish_and_clear();
+
+            println!(
+                "{} {}",
+                style("Certificate").bold(),
+                style(format!("({})", path.display())).dim()
+            );
+            println!("├─ {} {}", style("Peer ID:").bold(), style(peer_id).cyan());
+
+            Ok(())
+        }
+        args @ Commands::Init { output, .. } => {
+            let output = output.clone();
+            let config = builder::<Config>()
+                .with_provider(Serialized::defaults(&Config::default()))
+                .with_provider(Serialized::defaults(args))
+                .build()?
+                .validate()?;
+
+            fs::write(&output, &to_toml(&config.config).into_diagnostic()?).into_diagnostic()?;
+
+            println!("Configuration written to: {:?}", output);
+            Ok(())
+        }
+    }
+}
+
+fn create_spinner() -> ProgressBar {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_draw_target(ProgressDrawTarget::stderr_with_hz(60));
+    spinner.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .expect("valid spinner template")
+            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"),
+    );
+    spinner.enable_steady_tick(Duration::from_millis(120));
+
+    spinner
+}

--- a/crates/inspect/src/cli.rs
+++ b/crates/inspect/src/cli.rs
@@ -1,0 +1,238 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use indoc::indoc;
+use libp2p::{Multiaddr, PeerId};
+use serde::Serialize;
+
+#[derive(Debug, Parser, Serialize)]
+#[command(
+    name = "hypha-inspect",
+    version,
+    about = "Hypha Inspect - Network Diagnostics and Introspection Tool",
+    long_about = indoc!{"
+        Hypha Inspector is a CLI tool for diagnosing network connectivity,
+        inspecting routing tables, and verifying identities within the Hypha network.
+    "}
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, Serialize)]
+pub enum Commands {
+    #[command(
+        about = "Check if a remote peer is healthy and reachable",
+        long_about = indoc!{"
+            Connects to the specified multiaddr and performs a health check.
+
+            In verbose mode, prints detailed routing information and connection stats.
+        "}
+    )]
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file
+        #[arg(
+            short,
+            long("config"),
+            default_value = "config.toml",
+            verbatim_doc_comment
+        )]
+        config_file: PathBuf,
+
+        /// Target peer multiaddr to probe
+        #[arg(index = 1, verbatim_doc_comment)]
+        address: String,
+
+        /// Maximum time to wait for health response (milliseconds)
+        ///
+        /// If the peer doesn't respond within this duration, the probe fails.
+        /// Increase for high-latency networks or overloaded peers.
+        #[arg(long, default_value_t = 2000, verbatim_doc_comment)]
+        timeout: u64,
+
+        /// Path to the certificate PEM file (overrides config)
+        ///
+        /// Must be a valid X.509 certificate in PEM format. If not provided, uses
+        /// cert_pem from the configuration file.
+        #[arg(long("cert"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key PEM file (overrides config)
+        ///
+        /// Must correspond to the certificate. If not provided, uses key_pem from
+        /// the configuration file.
+        ///
+        /// SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+        #[arg(long("key"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust chain PEM file (overrides config)
+        ///
+        /// CA bundle containing certificates trusted by this node. If not provided,
+        /// uses trust_pem from the configuration file.
+        #[arg(long("trust"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list PEM (overrides config)
+        ///
+        /// Optional CRL for rejecting compromised certificates. If not provided,
+        /// uses crls_pem from the configuration file if present.
+        #[arg(long("crls"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+    },
+
+    #[command(
+        about = "Lookup a peer in the DHT via gateways",
+        long_about = indoc!{"
+            Connects to configured gateways and performs a DHT lookup for the given PeerID.
+            Prints the routing table information (closest peers, addresses) found.
+        "}
+    )]
+    #[serde(untagged)]
+    Lookup {
+        /// The PeerID to lookup
+        #[arg(index = 1)]
+        peer_id: PeerId,
+
+        /// Path to the configuration file
+        #[arg(
+            short,
+            long("config"),
+            default_value = "config.toml",
+            verbatim_doc_comment
+        )]
+        config_file: PathBuf,
+
+        /// Gateway addresses to connect to (repeatable, overrides config)
+        ///
+        /// Gateways provide network bootstrapping, DHT access, and optional relay.
+        ///
+        /// Examples:
+        ///   --gateway /ip4/203.0.113.10/tcp/8080/
+        ///   --gateway /dns4/gateway.hypha.example/tcp/443/
+        #[arg(long("gateway"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
+        /// Path to the certificate PEM file (overrides config)
+        ///
+        /// Must be a valid X.509 certificate in PEM format. If not provided, uses
+        /// cert_pem from the configuration file.
+        #[arg(long("cert"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key PEM file (overrides config)
+        ///
+        /// Must correspond to the certificate. If not provided, uses key_pem from
+        /// the configuration file.
+        ///
+        /// SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+        #[arg(long("key"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust chain PEM file (overrides config)
+        ///
+        /// CA bundle containing certificates trusted by this node. If not provided,
+        /// uses trust_pem from the configuration file.
+        #[arg(long("trust"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list PEM (overrides config)
+        ///
+        /// Optional CRL for rejecting compromised certificates. If not provided,
+        /// uses crls_pem from the configuration file if present.
+        #[arg(long("crls"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+    },
+
+    #[command(
+        about = "Derive PeerID from a certificate file",
+        long_about = indoc!{"
+            Reads an X.509 certificate or private key PEM file and prints the corresponding
+            libp2p PeerID.
+        "}
+    )]
+    #[serde(untagged)]
+    CertInfo {
+        /// Path to the PEM file (certificate or private key)
+        #[arg(index = 1, verbatim_doc_comment)]
+        path: PathBuf,
+    },
+
+    #[command(
+        about = "Identify this node and its network perspective",
+        long_about = indoc!{"
+            Connects to the network to discover how this node is seen by others (external address).
+            Also queries external IP echo services (Cloudflare, AWS) for tracing information.
+        "}
+    )]
+    #[command(
+        about = "Generate a default configuration file",
+        long_about = indoc!{"
+            Generate a default configuration file
+
+            Creates a TOML configuration file with sensible defaults.
+        "}
+    )]
+    #[serde(untagged)]
+    Init {
+        /// Path where the configuration file will be written
+        #[clap(short, long, default_value = "config.toml", verbatim_doc_comment)]
+        output: PathBuf,
+
+        /// Gateway addresses to connect to (repeatable, overrides config)
+        ///
+        /// Gateways provide network bootstrapping, DHT access, and optional relay.
+        ///
+        /// Examples:
+        ///   --gateway /ip4/203.0.113.10/tcp/8080/
+        ///   --gateway /dns4/gateway.hypha.example/tcp/443/
+        #[arg(long("gateway"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
+        /// Path to the certificate PEM file (overrides config)
+        ///
+        /// Must be a valid X.509 certificate in PEM format. If not provided, uses
+        /// cert_pem from the configuration file.
+        #[arg(long("cert"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key PEM file (overrides config)
+        ///
+        /// Must correspond to the certificate. If not provided, uses key_pem from
+        /// the configuration file.
+        ///
+        /// SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+        #[arg(long("key"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust chain PEM file (overrides config)
+        ///
+        /// CA bundle containing certificates trusted by this node. If not provided,
+        /// uses trust_pem from the configuration file.
+        #[arg(long("trust"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list PEM (overrides config)
+        ///
+        /// Optional CRL for rejecting compromised certificates. If not provided,
+        /// uses crls_pem from the configuration file if present.
+        #[arg(long("crls"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+    },
+}

--- a/crates/inspect/src/config.rs
+++ b/crates/inspect/src/config.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+
+use documented::{Documented, DocumentedFieldsOpt};
+use hypha_config::{ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Documented, DocumentedFieldsOpt)]
+/// Inspector configuration for network diagnostics and introspection.
+pub struct Config {
+    /// Path to the TLS certificate PEM file.
+    ///
+    /// Must be a valid X.509 certificate in PEM format that establishes the inspector's
+    /// identity when connecting to Hypha gateways.
+    ///
+    /// SECURITY: Use certificates from a recognized CA or internal PKI for deployments.
+    cert_pem: PathBuf,
+
+    /// Path to the private key PEM file.
+    ///
+    /// Must correspond to cert_pem. This is the inspector's cryptographic identity.
+    ///
+    /// SECURITY:
+    ///   * Restrict file permissions (chmod 600 recommended)
+    ///   * Never commit to version control
+    ///   * Store securely using secrets management systems in production
+    ///   * Keep encrypted backups for recovery
+    key_pem: PathBuf,
+
+    /// Path to the trust chain PEM file (CA bundle).
+    ///
+    /// Contains root and intermediate certificates trusted by the inspector. Peers presenting
+    /// certificates signed by these CAs will be accepted for network connections.
+    trust_pem: PathBuf,
+
+    /// Path to certificate revocation list PEM (optional).
+    ///
+    /// Lists certificates that should no longer be trusted, even if they appear in the trust
+    /// chain (e.g., compromised or retired peers).
+    ///
+    /// SECURITY: Keep this updated from your certificate authority to maintain security.
+    crls_pem: Option<PathBuf>,
+
+    /// Gateway addresses to connect to (required for network entry).
+    ///
+    /// Specifies one or more gateways for network bootstrapping and relay functionality.
+    /// Multiple gateways improve redundancy; the inspector attempts to connect to all
+    /// configured peers, succeeding if any are reachable.
+    ///
+    /// Examples:
+    /// * "/ip4/203.0.113.10/tcp/8080/"
+    /// * "/dns4/gateway.hypha.example/tcp/443/"
+    ///
+    /// NOTE: Defaults to placeholder addresses so users must configure real endpoints.
+    #[serde(alias = "gateways")]
+    gateway_addresses: Vec<Multiaddr>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            cert_pem: PathBuf::from("inspect-cert.pem"),
+            key_pem: PathBuf::from("inspect-key.pem"),
+            trust_pem: PathBuf::from("inspect-trust.pem"),
+            crls_pem: None,
+            gateway_addresses: vec![
+                "/ip4/1.2.3.4/tcp/1234"
+                    .parse()
+                    .expect("default address parses into a Multiaddr"),
+                "/ip4/1.2.3.5/udp/1234/quic-v1"
+                    .parse()
+                    .expect("default address parses into a Multiaddr"),
+            ],
+        }
+    }
+}
+
+impl Config {
+    pub fn gateway_addresses(&self) -> &Vec<Multiaddr> {
+        &self.gateway_addresses
+    }
+}
+
+impl TLSConfig for Config {
+    fn cert_pem_path(&self) -> &std::path::Path {
+        &self.cert_pem
+    }
+
+    fn key_pem_path(&self) -> &std::path::Path {
+        &self.key_pem
+    }
+
+    fn trust_pem_path(&self) -> &std::path::Path {
+        &self.trust_pem
+    }
+
+    fn crls_pem_path(&self) -> Option<&std::path::Path> {
+        self.crls_pem.as_deref()
+    }
+}
+
+impl ValidatableConfig for Config {
+    fn validate(
+        _cfg: &ConfigWithMetadata<Self>,
+    ) -> std::result::Result<(), hypha_config::ConfigError> {
+        Ok(())
+    }
+}

--- a/crates/inspect/src/lib.rs
+++ b/crates/inspect/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod network;

--- a/crates/inspect/src/network.rs
+++ b/crates/inspect/src/network.rs
@@ -1,0 +1,299 @@
+use std::{collections::HashMap, sync::Arc};
+
+use futures_util::stream::StreamExt;
+use hypha_network::{
+    CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
+    dial::{DialAction, DialDriver, DialInterface, PendingDials},
+    external_address::{ExternalAddressAction, ExternalAddressDriver, ExternalAddressInterface},
+    kad::{KademliaAction, KademliaBehavior, KademliaDriver, KademliaInterface, PendingQueries},
+    listen::{ListenAction, ListenDriver, ListenInterface, PendingListens},
+    request_response::{
+        OutboundRequests, OutboundResponses, RequestHandler, RequestResponseAction,
+        RequestResponseBehaviour, RequestResponseDriver, RequestResponseError,
+        RequestResponseInterface,
+    },
+    swarm::{SwarmDriver, SwarmError},
+};
+use libp2p::{
+    StreamProtocol, Swarm, SwarmBuilder, identify, kad, ping, request_response,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, tls, yamux,
+};
+use tokio::sync::{SetOnce, mpsc};
+
+#[derive(Clone)]
+pub struct Network {
+    action_sender: mpsc::Sender<Action>,
+}
+
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    ping: ping::Behaviour,
+    identify: identify::Behaviour,
+    kademlia: kad::Behaviour<kad::store::MemoryStore>,
+    health_request_response: request_response::Behaviour<HealthCodec>,
+}
+
+pub struct NetworkDriver {
+    swarm: Swarm<Behaviour>,
+    pending_dials_map: PendingDials,
+    pending_listen_map: PendingListens,
+    pending_queries_map: PendingQueries,
+    pending_bootstrap: Arc<SetOnce<()>>,
+    action_receiver: mpsc::Receiver<Action>,
+    health_outbound_requests_map: OutboundRequests<HealthCodec>,
+    health_outbound_responses_map: OutboundResponses,
+    health_request_handlers: Vec<RequestHandler<HealthCodec>>,
+    exclude_cidrs: Vec<IpNet>,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum Action {
+    Dial(DialAction),
+    Listen(ListenAction),
+    Kademlia(KademliaAction),
+    ExternalAddress(ExternalAddressAction),
+    HealthRequestResponse(RequestResponseAction<HealthCodec>),
+}
+
+type HealthCodec = hypha_messages::health::Codec;
+
+impl Network {
+    pub fn create(
+        cert_chain: Vec<CertificateDer<'static>>,
+        private_key: PrivateKeyDer<'static>,
+        ca_certs: Vec<CertificateDer<'static>>,
+        crls: Vec<CertificateRevocationListDer<'static>>,
+        exclude_cidrs: Vec<IpNet>,
+    ) -> Result<(Self, NetworkDriver), SwarmError> {
+        let (action_sender, action_receiver) = mpsc::channel(5);
+
+        let mut swarm =
+            SwarmBuilder::with_existing_identity(cert_chain, private_key, ca_certs, crls)
+                .with_tokio()
+                .with_tcp(
+                    tcp::Config::default(),
+                    tls::Config::new,
+                    yamux::Config::default,
+                )
+                .map_err(|_| {
+                    SwarmError::TransportConfig("Failed to create TCP transport.".to_string())
+                })?
+                .with_quic()
+                .with_dns()
+                .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
+                .with_behaviour(|key| Behaviour {
+                    ping: ping::Behaviour::new(ping::Config::new()),
+                    identify: identify::Behaviour::new(identify::Config::new(
+                        "/hypha-identify/0.0.1".to_string(),
+                        key.public(),
+                    )),
+                    kademlia: kad::Behaviour::new(
+                        key.public().to_peer_id(),
+                        kad::store::MemoryStore::new(key.public().to_peer_id()),
+                    ),
+                    health_request_response: request_response::Behaviour::<HealthCodec>::new(
+                        [(
+                            StreamProtocol::new(hypha_messages::health::IDENTIFIER),
+                            request_response::ProtocolSupport::Outbound,
+                        )],
+                        request_response::Config::default(),
+                    ),
+                })
+                .map_err(|_| {
+                    SwarmError::BehaviourCreation("Failed to create swarm behavior.".to_string())
+                })?
+                // TODO: Tune swarm configuration
+                .with_swarm_config(|config| config)
+                .build();
+
+        swarm
+            .behaviour_mut()
+            .kademlia
+            .set_mode(Some(kad::Mode::Client));
+
+        Ok((
+            Network { action_sender },
+            NetworkDriver {
+                swarm,
+                pending_dials_map: HashMap::default(),
+                pending_listen_map: HashMap::default(),
+                pending_queries_map: HashMap::default(),
+                pending_bootstrap: Arc::new(SetOnce::new()),
+                health_outbound_requests_map: HashMap::default(),
+                health_outbound_responses_map: HashMap::default(),
+                health_request_handlers: Vec::new(),
+                action_receiver,
+                exclude_cidrs,
+            },
+        ))
+    }
+}
+
+impl SwarmDriver<Behaviour> for NetworkDriver {
+    async fn run(mut self) -> Result<(), SwarmError> {
+        loop {
+            tokio::select! {
+                event = self.swarm.select_next_some() => {
+                    match event {
+                        SwarmEvent::ConnectionEstablished { connection_id, peer_id, .. } => {
+                            self.process_connection_established(peer_id, &connection_id).await;
+                        }
+                        SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
+                            self.process_connection_error(&connection_id, error).await;
+                        }
+                        SwarmEvent::NewListenAddr { listener_id, address } => {
+                            self.process_new_listen_addr(&listener_id, address).await;
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Identify(event)) => {
+                            self.process_identify_event(event);
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Kademlia(kad::Event::OutboundQueryProgressed {id,  result, step, ..})) => {
+                            self.process_kademlia_query_result(id, result, step).await;
+                         }
+                        SwarmEvent::Behaviour(BehaviourEvent::HealthRequestResponse(event)) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, HealthCodec>>::process_request_response_event(&mut self, event).await;
+                        }
+                        _ => {
+                            tracing::debug!("Unhandled event: {:?}", event);
+                        }
+                    }
+                },
+                Some(action) = self.action_receiver.recv() => {
+                    match action {
+                        Action::Dial(action) => {
+                            self.process_dial_action(action).await;
+                        },
+                        Action::Listen(action) => { self.process_listen_action(action).await; },
+                        Action::Kademlia(action) => { self.process_kademlia_action(action).await; },
+                        Action::ExternalAddress(action) => {
+                            self.process_external_address_action(action).await;
+                        }
+                        Action::HealthRequestResponse(action) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, HealthCodec>>::process_request_response_action(&mut self, action).await;
+                        }
+                    }
+                }
+                else => break
+            }
+        }
+
+        Ok(())
+    }
+
+    fn swarm(&mut self) -> &mut Swarm<Behaviour> {
+        &mut self.swarm
+    }
+}
+
+impl DialInterface for Network {
+    async fn send(&self, action: DialAction) {
+        self.action_sender
+            .send(Action::Dial(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}
+
+impl DialDriver<Behaviour> for NetworkDriver {
+    fn pending_dials(&mut self) -> &mut PendingDials {
+        &mut self.pending_dials_map
+    }
+
+    fn exclude_cidrs(&self) -> &[IpNet] {
+        &self.exclude_cidrs
+    }
+}
+
+impl ListenInterface for Network {
+    async fn send(&self, action: ListenAction) {
+        self.action_sender
+            .send(Action::Listen(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}
+
+impl ListenDriver<Behaviour> for NetworkDriver {
+    fn pending_listens(&mut self) -> &mut PendingListens {
+        &mut self.pending_listen_map
+    }
+}
+
+impl ExternalAddressDriver<Behaviour> for NetworkDriver {}
+
+impl ExternalAddressInterface for Network {
+    async fn send(&self, action: ExternalAddressAction) {
+        self.action_sender
+            .send(Action::ExternalAddress(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}
+
+impl RequestResponseBehaviour<HealthCodec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<HealthCodec> {
+        &mut self.health_request_response
+    }
+}
+
+impl RequestResponseDriver<Behaviour, HealthCodec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<HealthCodec> {
+        &mut self.health_outbound_requests_map
+    }
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses {
+        &mut self.health_outbound_responses_map
+    }
+
+    fn request_handlers(&mut self) -> &mut Vec<RequestHandler<HealthCodec>> {
+        &mut self.health_request_handlers
+    }
+}
+
+impl RequestResponseInterface<HealthCodec> for Network {
+    async fn send(&self, action: RequestResponseAction<HealthCodec>) {
+        self.action_sender
+            .send(Action::HealthRequestResponse(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+
+    fn try_send(
+        &self,
+        action: RequestResponseAction<HealthCodec>,
+    ) -> Result<(), RequestResponseError> {
+        self.action_sender
+            .try_send(Action::HealthRequestResponse(action))
+            .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
+    }
+}
+
+impl KademliaBehavior for Behaviour {
+    fn kademlia(&mut self) -> &mut kad::Behaviour<kad::store::MemoryStore> {
+        &mut self.kademlia
+    }
+}
+
+impl KademliaDriver<Behaviour> for NetworkDriver {
+    fn pending_queries(&mut self) -> &mut PendingQueries {
+        &mut self.pending_queries_map
+    }
+
+    fn pending_bootstrap(&mut self) -> &mut Arc<SetOnce<()>> {
+        &mut self.pending_bootstrap
+    }
+
+    fn exclude_cidrs(&self) -> Vec<IpNet> {
+        self.exclude_cidrs.clone()
+    }
+}
+
+impl KademliaInterface for Network {
+    async fn send(&self, action: KademliaAction) {
+        self.action_sender
+            .send(Action::Kademlia(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -32,6 +32,7 @@ installing to ~/.local/bin
   hypha-data
   hypha-scheduler
   hypha-certutil
+  hypha-inspect
 everything's installed!
 ```
 For a list of available versions, visit the [GitHub Releases](https://github.com/hypha-space/hypha/releases) page.
@@ -55,7 +56,8 @@ cargo install --git https://github.com/hypha-space/hypha \
     hypha-data \
     hypha-gateway \
     hypha-scheduler \
-    hypha-worker
+    hypha-worker \
+    hypha-inspect
 ```
 
 > [!NOTE]
@@ -70,7 +72,8 @@ rm -f ~/.local/bin/hypha-certutil \
     ~/.local/bin/hypha-data \
     ~/.local/bin/hypha-gateway \
     ~/.local/bin/hypha-scheduler \
-    ~/.local/bin/hypha-worker
+    ~/.local/bin/hypha-worker \
+    ~/.local/bin/hypha-inspect
 ```
 
 ## Next steps

--- a/docs/content/reference/hypha-inspect-cli.md
+++ b/docs/content/reference/hypha-inspect-cli.md
@@ -1,0 +1,181 @@
++++
+title = "hypha-inspect CLI"
+description = "Auto-generated reference for the hypha-inspect command, covering configuration and operational subcommands."
+[taxonomies]
+track = ["reference"]
++++
+
+<!-- NOTE: Auto-generated. Do not edit manually. -->
+
+# hypha-inspect CLI Reference
+
+This document contains the help content for the `hypha-inspect` command-line program.
+
+**Command Overview:**
+
+* [`hypha-inspect`↴](#hypha-inspect)
+* [`hypha-inspect probe`↴](#hypha-inspect-probe)
+* [`hypha-inspect lookup`↴](#hypha-inspect-lookup)
+* [`hypha-inspect cert-info`↴](#hypha-inspect-cert-info)
+* [`hypha-inspect init`↴](#hypha-inspect-init)
+
+## `hypha-inspect`
+
+Hypha Inspect is a CLI tool for diagnosing network connectivity,
+inspecting routing tables, and verifying identities within the Hypha network.
+
+
+**Usage:** `hypha-inspect <COMMAND>`
+
+###### **Subcommands:**
+
+* `probe` — Check if a remote peer is healthy and reachable
+* `lookup` — Lookup a peer in the DHT via gateways
+* `cert-info` — Derive PeerID from a certificate file
+* `init` — Generate a default configuration file
+
+
+
+## `hypha-inspect probe`
+
+Connects to the specified multiaddr and performs a health check.
+
+In verbose mode, prints detailed routing information and connection stats.
+
+
+**Usage:** `hypha-inspect probe [OPTIONS] <ADDRESS>`
+
+###### **Arguments:**
+
+* `<ADDRESS>` — Target peer multiaddr to probe
+
+###### **Options:**
+
+* `-c`, `--config <CONFIG_FILE>` — Path to the configuration file
+
+  Default value: `config.toml`
+* `--timeout <TIMEOUT>` — Maximum time to wait for health response (milliseconds)
+
+   If the peer doesn't respond within this duration, the probe fails.
+   Increase for high-latency networks or overloaded peers.
+
+  Default value: `2000`
+* `--cert <CERT_PEM>` — Path to the certificate PEM file (overrides config)
+
+   Must be a valid X.509 certificate in PEM format. If not provided, uses
+   cert_pem from the configuration file.
+* `--key <KEY_PEM>` — Path to the private key PEM file (overrides config)
+
+   Must correspond to the certificate. If not provided, uses key_pem from
+   the configuration file.
+
+   SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+* `--trust <TRUST_PEM>` — Path to the trust chain PEM file (overrides config)
+
+   CA bundle containing certificates trusted by this node. If not provided,
+   uses trust_pem from the configuration file.
+* `--crls <CRLS_PEM>` — Path to the certificate revocation list PEM (overrides config)
+
+   Optional CRL for rejecting compromised certificates. If not provided,
+   uses crls_pem from the configuration file if present.
+
+
+
+## `hypha-inspect lookup`
+
+Connects to configured gateways and performs a DHT lookup for the given PeerID.
+Prints the routing table information (closest peers, addresses) found.
+
+
+**Usage:** `hypha-inspect lookup [OPTIONS] <PEER_ID>`
+
+###### **Arguments:**
+
+* `<PEER_ID>` — The PeerID to lookup
+
+###### **Options:**
+
+* `-c`, `--config <CONFIG_FILE>` — Path to the configuration file
+
+  Default value: `config.toml`
+* `--gateway <GATEWAY_ADDRESSES>` — Gateway addresses to connect to (repeatable, overrides config)
+
+   Gateways provide network bootstrapping, DHT access, and optional relay.
+
+   Examples:
+     --gateway /ip4/203.0.113.10/tcp/8080/
+     --gateway /dns4/gateway.hypha.example/tcp/443/
+* `--cert <CERT_PEM>` — Path to the certificate PEM file (overrides config)
+
+   Must be a valid X.509 certificate in PEM format. If not provided, uses
+   cert_pem from the configuration file.
+* `--key <KEY_PEM>` — Path to the private key PEM file (overrides config)
+
+   Must correspond to the certificate. If not provided, uses key_pem from
+   the configuration file.
+
+   SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+* `--trust <TRUST_PEM>` — Path to the trust chain PEM file (overrides config)
+
+   CA bundle containing certificates trusted by this node. If not provided,
+   uses trust_pem from the configuration file.
+* `--crls <CRLS_PEM>` — Path to the certificate revocation list PEM (overrides config)
+
+   Optional CRL for rejecting compromised certificates. If not provided,
+   uses crls_pem from the configuration file if present.
+
+
+
+## `hypha-inspect cert-info`
+
+Reads an X.509 certificate or private key PEM file and prints the corresponding
+libp2p PeerID.
+
+
+**Usage:** `hypha-inspect cert-info <PATH>`
+
+###### **Arguments:**
+
+* `<PATH>` — Path to the PEM file (certificate or private key)
+
+
+
+## `hypha-inspect init`
+
+Generate a default configuration file
+
+Creates a TOML configuration file with sensible defaults.
+
+
+**Usage:** `hypha-inspect init [OPTIONS]`
+
+###### **Options:**
+
+* `-o`, `--output <OUTPUT>` — Path where the configuration file will be written
+
+  Default value: `config.toml`
+* `--gateway <GATEWAY_ADDRESSES>` — Gateway addresses to connect to (repeatable, overrides config)
+
+   Gateways provide network bootstrapping, DHT access, and optional relay.
+
+   Examples:
+     --gateway /ip4/203.0.113.10/tcp/8080/
+     --gateway /dns4/gateway.hypha.example/tcp/443/
+* `--cert <CERT_PEM>` — Path to the certificate PEM file (overrides config)
+
+   Must be a valid X.509 certificate in PEM format. If not provided, uses
+   cert_pem from the configuration file.
+* `--key <KEY_PEM>` — Path to the private key PEM file (overrides config)
+
+   Must correspond to the certificate. If not provided, uses key_pem from
+   the configuration file.
+
+   SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+* `--trust <TRUST_PEM>` — Path to the trust chain PEM file (overrides config)
+
+   CA bundle containing certificates trusted by this node. If not provided,
+   uses trust_pem from the configuration file.
+* `--crls <CRLS_PEM>` — Path to the certificate revocation list PEM (overrides config)
+
+   Optional CRL for rejecting compromised certificates. If not provided,
+   uses crls_pem from the configuration file if present.

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ set -u
 
 APP_NAME="hypha"
 VERSION=""
-BINARIES="hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil"
+BINARIES="hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil hypha-inspect"
 
 if [ -n "${HYPHA_INSTALLER_BASE_URL:-}" ]; then
     INSTALLER_BASE_URL="$HYPHA_INSTALLER_BASE_URL"


### PR DESCRIPTION
Introduce `hypha-inspect` so operators can probe peers, inspect certificates, and lookup addresses in the DHT for debugging purposes and setup verification.