### PR TITLE
feat: upload trained model to hf

### DIFF
--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -115,6 +115,10 @@ pub mod progress {
         },
         Done,
         Error,
+        PushToHF {
+            repository: String,
+            token: String,
+        },
     }
 }
 

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -301,6 +301,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
             allocated_parameter_servers[0].peer_id(),
             diloco_config.rounds.avg_samples_between_updates,
             diloco_config.rounds.update_rounds,
+            diloco_config.model_destination.clone(),
         )));
 
         let (metrics_rx, batch_scheduler_handle) = BatchScheduler::run::<

--- a/crates/scheduler/src/scheduler_config.rs
+++ b/crates/scheduler/src/scheduler_config.rs
@@ -32,6 +32,7 @@ pub struct DiLoCo {
     #[serde(rename = "outer_optimizer")]
     pub outer_optimizer: Nesterov,
     pub resources: DiLoCoResources,
+    pub model_destination: Option<ModelDestiantion>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy)]
@@ -100,6 +101,7 @@ impl Default for DiLoCo {
                 worker_price: PriceRange::default(),
                 parameter_server_price: PriceRange::default(),
             },
+            model_destination: None,
         }
     }
 }
@@ -128,6 +130,12 @@ impl From<ModelSource> for Model {
             input_names: source.input_names,
         }
     }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ModelDestiantion {
+    pub repository: String,
+    pub token: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/crates/scheduler/src/scheduling/batch_scheduler.rs
+++ b/crates/scheduler/src/scheduling/batch_scheduler.rs
@@ -150,7 +150,7 @@ where
                 {
                     notifier.notify_one();
                 }
-                Ok(progress::Response::Done {})
+                Ok(tracker.upload().unwrap_or(progress::Response::Done {}))
             } else {
                 tracker
                     .worker_tracker
@@ -252,6 +252,7 @@ mod batch_scheduler_tests {
             PeerId::random(),
             1024,
             2,
+            None,
         )));
         let (tx, mut rx) = channel(3);
         let peer_id = PeerId::random();
@@ -345,7 +346,9 @@ mod batch_scheduler_tests {
     #[tokio::test]
     async fn handle_simple_two_rounds() {
         let ps = PeerId::random();
-        let tracker = Arc::new(Mutex::new(ProgressTracker::<RunningMean>::new(ps, 800, 2)));
+        let tracker = Arc::new(Mutex::new(ProgressTracker::<RunningMean>::new(
+            ps, 800, 2, None,
+        )));
         tokio::time::pause();
         let w1 = PeerId::random();
         tracker.lock().await.worker_tracker.add_worker(w1, 150);
@@ -448,7 +451,9 @@ mod batch_scheduler_tests {
     #[tokio::test]
     async fn single_worker_responding() {
         let ps = PeerId::random();
-        let tracker = Arc::new(Mutex::new(ProgressTracker::<RunningMean>::new(ps, 200, 2)));
+        let tracker = Arc::new(Mutex::new(ProgressTracker::<RunningMean>::new(
+            ps, 200, 2, None,
+        )));
         tokio::time::pause();
         let w1 = PeerId::random();
         tracker.lock().await.worker_tracker.add_worker(w1, 150);

--- a/crates/scheduler/src/tracker/progress.rs
+++ b/crates/scheduler/src/tracker/progress.rs
@@ -1,7 +1,9 @@
+use hypha_messages::progress;
 use libp2p::PeerId;
 use tokio::time::Instant;
 
 use crate::{
+    scheduler_config::ModelDestiantion,
     statistics::RuntimeStatistic,
     tracker::worker::{WorkerTracker, WorkerTrackerError},
 };
@@ -16,6 +18,7 @@ where
     round_start_instant: Instant,
     update_epochs: u32,
     update_counter: u32,
+    pub upload_to_hf: Option<ModelDestiantion>,
     pub worker_tracker: WorkerTracker<T>,
 }
 
@@ -23,7 +26,12 @@ impl<T> ProgressTracker<T>
 where
     T: RuntimeStatistic,
 {
-    pub fn new(parameter_server: PeerId, update_target: u32, update_epochs: u32) -> Self {
+    pub fn new(
+        parameter_server: PeerId,
+        update_target: u32,
+        update_epochs: u32,
+        upload_to_hf: Option<ModelDestiantion>,
+    ) -> Self {
         ProgressTracker {
             counter: update_target,
             parameter_server,
@@ -31,6 +39,7 @@ where
             round_start_instant: tokio::time::Instant::now(),
             update_epochs,
             update_counter: 0,
+            upload_to_hf,
             worker_tracker: WorkerTracker::<T>::new(),
         }
     }
@@ -64,6 +73,18 @@ where
     pub fn training_finished(&self) -> bool {
         self.update_counter == self.update_epochs
     }
+
+    pub fn upload(&mut self) -> Option<progress::Response> {
+        let result = self
+            .upload_to_hf
+            .as_ref()
+            .map(|destination| progress::Response::PushToHF {
+                repository: destination.repository.clone(),
+                token: destination.token.clone(),
+            });
+        self.upload_to_hf = None;
+        result
+    }
 }
 
 #[cfg(test)]
@@ -95,7 +116,7 @@ mod tests {
 
     #[tokio::test]
     async fn peer_info() {
-        let mut tracker = ProgressTracker::<RunningMean>::new(PeerId::random(), 1024, 1);
+        let mut tracker = ProgressTracker::<RunningMean>::new(PeerId::random(), 1024, 1, None);
         tokio::time::pause();
         let p1 = PeerId::random();
         tracker.worker_tracker.add_worker(p1, 2);
@@ -129,7 +150,7 @@ mod tests {
 
     #[test]
     fn peer_state() {
-        let mut tracker = ProgressTracker::<RunningMean>::new(PeerId::random(), 1024, 1);
+        let mut tracker = ProgressTracker::<RunningMean>::new(PeerId::random(), 1024, 1, None);
         let p1 = PeerId::random();
         tracker.worker_tracker.add_worker(p1, 2);
 
@@ -149,7 +170,7 @@ mod tests {
 
     #[test]
     fn parameter_server_update() {
-        let mut tracker = ProgressTracker::<RunningMean>::new(PeerId::random(), 1024, 1);
+        let mut tracker = ProgressTracker::<RunningMean>::new(PeerId::random(), 1024, 1, None);
         let ps = PeerId::random();
         tracker.update_parameter_server(ps);
         assert_eq!(tracker.parameter_server, ps)

--- a/docs/content/scheduler.md
+++ b/docs/content/scheduler.md
@@ -79,6 +79,9 @@ token = "hf_..."                           # Optional auth token
 type = "vision-classification"             # Model type
 ```
 
+> [!IMPORTANT]
+> The token will be shared with all workers. Only use a token with limited rights and invalidate the token at the end.
+
 Supported model types:
 
 - `vision-classification`: Image classification models (AutoModelForImageClassification)
@@ -93,6 +96,9 @@ repository = "l45k/Resnet50"
 filenames = ["preprocessor_config.json"]
 token = "hf_..."
 ```
+
+> [!IMPORTANT]
+> The token will be shared with all workers. Only use a token with limited rights and invalidate the token at the end.
 
 **Dataset Configuration**:
 
@@ -117,6 +123,20 @@ learning_rate = 0.001
 learning_rate = 0.7
 momentum = 0.9
 ```
+
+**Upload Trained Model To HF**:
+To upload the trained model to Hugging Face provide a repository and a token with with the correct rights:
+
+```toml
+[scheduler.job.model_destination]
+repository="repository/identifier"
+token="hf_*"
+```
+
+> [!IMPORTANT]
+> This will override any existing model and model weights in the repositry and if the repository doesn't exist, it will
+try to create a new repository with the account defaults (if not changed it will be a public repositry). Additionally,
+the token will be shared with a worker. Only use a token with limited rights and invalidate the token at the end.
 
 **Resource Requirements**:
 

--- a/executors/accelerate/src/hypha/accelerate_executor/training.py
+++ b/executors/accelerate/src/hypha/accelerate_executor/training.py
@@ -88,13 +88,18 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
                                     # Load new model with outer gradients
                                     model.load_state_dict(merge_models(previous_model_path, path))
                                     # over write previous model
-                                    save_model(model, previous_model_path)
-                                    model = accelerator.prepare(model)
-                                    print("Weights updated from", rel_path, flush=True)
                                     response = session.send_status("update-received")
                                     if response["type"] == "Done":
                                         print("Training finished")
                                         break
+                                    if response["type"] == "PushToHF":
+                                        model.push_to_hub(response["repository"], token=response["token"])
+                                        print("Model pushed. Traning finished")
+                                        break
+
+                                    save_model(model, previous_model_path)
+                                    model = accelerator.prepare(model)
+                                    print("Weights updated from", rel_path, flush=True)
                             except Exception as e:
                                 print(f"pointer handling error: {e}")
                     except StopIteration:


### PR DESCRIPTION
This will upload a trained model to a Hugging Face repositry if the following is porvided in the Schedulers' `conifg.toml`

```toml
[scheduler.job.model_destination]
repositry = "repositry/identifier"
token = "hf_*"
```