### PR TITLE
improve trouble shooting

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,7 @@ jobs:
         with:
           version: ${{ needs.get-next-version.outputs.new-release-version }}
           target: ${{ matrix.target }}
-          binaries: "hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil"
+          binaries: "hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil hypha-inspect"
 
   github-release:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +681,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1995,6 +2014,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypha-inspect"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "clap-markdown",
+ "console 0.15.11",
+ "documented",
+ "figment",
+ "futures-util",
+ "hypha-config",
+ "hypha-messages",
+ "hypha-network",
+ "indicatif",
+ "indoc",
+ "libp2p",
+ "miette",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-indicatif",
+ "tracing-subscriber",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
 name = "hypha-leases"
 version = "0.0.0"
 dependencies = [
@@ -2329,10 +2375,11 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
+ "console 0.16.1",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
+ "vt100",
  "web-time",
 ]
 
@@ -5294,6 +5341,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-indicatif"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d4e11e0e27acef25a47f27e9435355fecdc488867fa2bc90e75b0700d2823d"
+dependencies = [
+ "indicatif",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5522,6 +5581,27 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vt100"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
+dependencies = [
+ "itoa",
+ "unicode-width 0.2.2",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -5765,6 +5845,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/worker",
     "crates/telemetry",
     "crates/resources",
+    "crates/inspect",
 ]
 default-members = [
     "crates/certutil",
@@ -19,7 +20,7 @@ default-members = [
     "crates/gateway",
     "crates/scheduler",
     "crates/worker",
-
+    "crates/inspect",
 ]
 
 [workspace.package]
@@ -37,6 +38,8 @@ figment = { version = "0.10", features = ["toml", "env"] }
 indoc = "2"
 futures-util = "0.3"
 http-body-util = "0.1.3"
+indicatif = "0.18.3"
+console = "0.15.8"
 hypha-config = { path = "crates/config" }
 hypha-leases = { path = "crates/leases" }
 hypha-messages = { path = "crates/messages" }
@@ -93,6 +96,7 @@ toml = { version = "0.9.5" }
 tower = { version = "0.5.2", features = ["util"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+tracing-indicatif = "0.3.6"
 utoipa = { version = "5.4.0", features = ["axum_extras", "url", "uuid"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 

--- a/crates/inspect/Cargo.toml
+++ b/crates/inspect/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "hypha-inspect"
+version.workspace = true
+publish.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+
+[dependencies]
+clap.workspace = true
+documented.workspace = true
+figment.workspace = true
+futures-util.workspace = true
+hypha-config.workspace = true
+hypha-messages.workspace = true
+hypha-network.workspace = true
+indicatif.workspace = true
+indoc.workspace = true
+libp2p.workspace = true
+miette.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-indicatif.workspace = true
+tracing-subscriber.workspace = true
+console.workspace = true
+x509-parser = "0.16"
+
+[build-dependencies]
+clap.workspace = true
+clap-markdown = "0.1.5"
+indoc.workspace = true
+libp2p.workspace = true
+serde.workspace = true

--- a/crates/inspect/build.rs
+++ b/crates/inspect/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+use clap_markdown::{MarkdownOptions, help_markdown_custom};
+
+#[allow(dead_code)]
+mod cli {
+    include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/cli.rs"));
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cli.rs");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let docs_path = out_dir.join(format!("{}-cli.md", env!("CARGO_PKG_NAME")));
+
+    let crate_name = env!("CARGO_PKG_NAME");
+    let options = MarkdownOptions::new()
+        .title(format!("{crate_name} CLI Reference"))
+        .show_footer(false);
+    let body = help_markdown_custom::<cli::Cli>(&options);
+
+    let content = format!(
+        "<!-- NOTE: Auto-generated. Do not edit manually. -->\n\n{}\n",
+        body.trim_end()
+    );
+
+    fs::write(&docs_path, content).expect("failed to write CLI docs");
+}

--- a/crates/inspect/src/bin/hypha-inspect.rs
+++ b/crates/inspect/src/bin/hypha-inspect.rs
@@ -1,0 +1,287 @@
+use std::{fs, time::Duration};
+
+use clap::Parser;
+use console::style;
+use figment::providers::{Env, Format, Serialized, Toml};
+use futures_util::future::join_all;
+use hypha_config::{ConfigWithMetadataTLSExt, builder, to_toml};
+use hypha_inspect::{config::Config, network::Network};
+use hypha_messages::health;
+use hypha_network::{
+    cert, dial::DialInterface, kad::KademliaInterface,
+    request_response::RequestResponseInterfaceExt, swarm::SwarmDriver,
+};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use libp2p::Multiaddr;
+use miette::{IntoDiagnostic, Result};
+use tracing_indicatif::{
+    IndicatifLayer,
+    filter::{IndicatifFilter, hide_indicatif_span_fields},
+};
+use tracing_subscriber::{
+    EnvFilter, Layer, fmt::format::DefaultFields, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+#[path = "../cli.rs"]
+mod cli;
+use cli::{Cli, Commands};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Initialize tracing (simplified for CLI tool)
+    // Only initialize if NO OTHER subscriber is set (e.g. via env vars)
+    let indicatif_layer = IndicatifLayer::new()
+        .with_span_field_formatter(hide_indicatif_span_fields(DefaultFields::new()));
+    let indicatif_writer = indicatif_layer.get_stderr_writer();
+    let indicatif_layer = indicatif_layer.with_filter(IndicatifFilter::new(false));
+    if tracing_subscriber::registry()
+        .with(indicatif_layer)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(indicatif_writer)
+                .with_filter(EnvFilter::from_default_env()),
+        )
+        .try_init()
+        .is_err()
+    {
+        // Already initialized? Ignore.
+    }
+
+    match &cli.command {
+        args @ Commands::Probe {
+            config_file,
+            address,
+            timeout,
+            ..
+        } => {
+            let spinner = create_spinner();
+
+            spinner.set_message(format!("Dailing {address}..."));
+
+            let config = builder::<Config>()
+                .with_provider(Toml::file(config_file))
+                .with_provider(Env::prefixed("HYPHA_"))
+                .with_provider(Serialized::defaults(args))
+                .build()?
+                .validate()?;
+
+            let cert_chain = config.load_cert_chain()?;
+            let private_key = config.load_key()?;
+            let ca_certs = config.load_trust_chain()?;
+            let crls = config.load_crls()?;
+
+            let exclude_cidrs = hypha_network::reserved_cidrs();
+
+            let (network, network_driver) =
+                Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
+                    .into_diagnostic()?;
+
+            let network_driver_task = tokio::spawn(network_driver.run());
+
+            let addr: Multiaddr = address.parse().into_diagnostic()?;
+
+            tokio::time::timeout(Duration::from_millis(*timeout), {
+                let network = network.clone();
+
+                async move {
+                    let peer_id = network.dial(addr).await.into_diagnostic()?;
+
+                    spinner.set_message(format!("Health checking {peer_id}..."));
+
+                    let resp = network
+                        .request::<health::Codec>(peer_id, health::Request {})
+                        .await
+                        .into_diagnostic()?;
+
+                    spinner.finish_and_clear();
+
+                    println!(
+                        "{} {}",
+                        style("Address").bold(),
+                        style(format!("({address})")).dim()
+                    );
+                    println!("├─ {} {}", style("Peer ID:").bold(), style(peer_id));
+
+                    if resp.healthy {
+                        println!(
+                            "├─ {} {}",
+                            style("Status:").bold(),
+                            style("Healthy").green()
+                        );
+
+                        Ok(())
+                    } else {
+                        println!(
+                            "├─ {} {}",
+                            style("Status:").bold(),
+                            style("Unhealthy").red()
+                        );
+
+                        Err(miette::miette!("The peer is unhealthy"))
+                    }
+                }
+            })
+            .await
+            .into_diagnostic()??;
+
+            drop(network);
+            if !network_driver_task.is_finished() {
+                network_driver_task.abort();
+            }
+            Ok(())
+        }
+        args @ Commands::Lookup {
+            config_file,
+            peer_id,
+            ..
+        } => {
+            let peer_id = *peer_id;
+            let spinner = create_spinner();
+
+            spinner.set_message("Joining network...");
+
+            let config = builder::<Config>()
+                .with_provider(Toml::file(config_file))
+                .with_provider(Env::prefixed("HYPHA_"))
+                .with_provider(Serialized::defaults(args))
+                .build()?
+                .validate()?;
+
+            let cert_chain = config.load_cert_chain()?;
+            let private_key = config.load_key()?;
+            let ca_certs = config.load_trust_chain()?;
+            let crls = config.load_crls()?;
+
+            let exclude_cidrs = hypha_network::reserved_cidrs();
+
+            let (network, network_driver) =
+                Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
+                    .into_diagnostic()?;
+
+            let network_driver_task = tokio::spawn(network_driver.run());
+
+            let gateway_peer_ids: Vec<_> = join_all(
+                config
+                    .gateway_addresses()
+                    .iter()
+                    .map(|address| {
+                        let network = network.clone();
+                        async move { network.dial(address.clone()).await }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .await
+            .into_iter()
+            .filter_map(|result| result.ok())
+            .collect();
+
+            if gateway_peer_ids.is_empty() {
+                return Err(miette::miette!("Failed to connect to any gateway"));
+            }
+
+            tracing::info!(gateway_ids = ?gateway_peer_ids, "Connected to gateway(s)");
+
+            network.wait_for_bootstrap().await.into_diagnostic()?;
+
+            spinner.set_message(format!("Querying DHT for {peer_id}..."));
+
+            let closest_peers = network.get_closest_peers(peer_id).await.into_diagnostic()?;
+            if let Some(peer) = closest_peers
+                .iter()
+                .find(|peer| peer.peer_id == peer_id)
+                .cloned()
+            {
+                spinner.finish_and_clear();
+
+                println!(
+                    "{} {}",
+                    style("Peer").bold(),
+                    style(format!("({peer_id})")).dim()
+                );
+                for addr in peer.addrs {
+                    println!("├─ {} {}", style("Address:").dim(), style(addr));
+                }
+            } else {
+                return Err(miette::miette!("No peer with ID {} found.", peer_id));
+            }
+
+            drop(network);
+            if !network_driver_task.is_finished() {
+                network_driver_task.abort();
+            }
+            Ok(())
+        }
+        Commands::CertInfo { path } => {
+            let path = path.clone();
+            let spinner = create_spinner();
+            spinner.set_message(format!("Inspecting {}...", path.display()));
+            let content = fs::read(&path).into_diagnostic()?;
+
+            // Try private key first
+            if let Ok(key) = cert::load_private_key_from_pem(&content)
+                && let Ok(identity) = cert::identity_from_private_key(&key)
+            {
+                spinner.finish_and_clear();
+
+                let peer_id = identity.public().to_peer_id();
+                println!(
+                    "{} {}",
+                    style("Private Key").bold().on_red(),
+                    style(format!("({})", path.display())).dim()
+                );
+                println!("├─ {} {}", style("Peer ID:").bold(), style(peer_id).cyan());
+
+                return Ok(());
+            }
+
+            // Try certificate
+            let (_rem, pem) = x509_parser::pem::parse_x509_pem(&content).into_diagnostic()?;
+            let cert = pem.parse_x509().into_diagnostic()?;
+
+            let ed_key = libp2p::identity::ed25519::PublicKey::try_from_bytes(
+                &cert.tbs_certificate.subject_pki.subject_public_key.data,
+            )
+            .into_diagnostic()?;
+
+            let peer_id = libp2p::identity::PublicKey::from(ed_key).to_peer_id();
+            spinner.finish_and_clear();
+
+            println!(
+                "{} {}",
+                style("Certificate").bold(),
+                style(format!("({})", path.display())).dim()
+            );
+            println!("├─ {} {}", style("Peer ID:").bold(), style(peer_id).cyan());
+
+            Ok(())
+        }
+        args @ Commands::Init { output, .. } => {
+            let output = output.clone();
+            let config = builder::<Config>()
+                .with_provider(Serialized::defaults(&Config::default()))
+                .with_provider(Serialized::defaults(args))
+                .build()?
+                .validate()?;
+
+            fs::write(&output, &to_toml(&config.config).into_diagnostic()?).into_diagnostic()?;
+
+            println!("Configuration written to: {:?}", output);
+            Ok(())
+        }
+    }
+}
+
+fn create_spinner() -> ProgressBar {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_draw_target(ProgressDrawTarget::stderr_with_hz(60));
+    spinner.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .expect("valid spinner template")
+            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"),
+    );
+    spinner.enable_steady_tick(Duration::from_millis(120));
+
+    spinner
+}

--- a/crates/inspect/src/cli.rs
+++ b/crates/inspect/src/cli.rs
@@ -1,0 +1,230 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use indoc::indoc;
+use libp2p::{Multiaddr, PeerId};
+use serde::Serialize;
+
+#[derive(Debug, Parser, Serialize)]
+#[command(
+    name = "hypha-inspect",
+    version,
+    about = "Hypha Inspect - Network Diagnostics and Introspection Tool",
+    long_about = indoc!{"
+        Hypha Inspector is a CLI tool for diagnosing network connectivity,
+        inspecting routing tables, and verifying identities within the Hypha network.
+    "}
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand, Serialize)]
+pub enum Commands {
+    #[command(
+        about = "Check if a remote peer is healthy and reachable",
+        long_about = indoc!{"
+            Connects to the specified multiaddr and performs a health check.
+
+            In verbose mode, prints detailed routing information and connection stats.
+        "}
+    )]
+    #[serde(untagged)]
+    Probe {
+        /// Path to the configuration file
+        #[arg(
+            short,
+            long("config"),
+            default_value = "config.toml",
+            verbatim_doc_comment
+        )]
+        config_file: PathBuf,
+
+        /// Target peer multiaddr to probe
+        #[arg(index = 1, verbatim_doc_comment)]
+        address: String,
+
+        /// Maximum time to wait for health response (milliseconds)
+        ///
+        /// If the peer doesn't respond within this duration, the probe fails.
+        /// Increase for high-latency networks or overloaded peers.
+        #[arg(long, default_value_t = 2000, verbatim_doc_comment)]
+        timeout: u64,
+
+        /// Path to the certificate PEM file (overrides config)
+        ///
+        /// Must be a valid X.509 certificate in PEM format. If not provided, uses
+        /// cert_pem from the configuration file.
+        #[arg(long("cert"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key PEM file (overrides config)
+        ///
+        /// Must correspond to the certificate. If not provided, uses key_pem from
+        /// the configuration file.
+        ///
+        /// SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+        #[arg(long("key"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust chain PEM file (overrides config)
+        ///
+        /// CA bundle containing certificates trusted by this node. If not provided,
+        /// uses trust_pem from the configuration file.
+        #[arg(long("trust"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list PEM (overrides config)
+        ///
+        /// Optional CRL for rejecting compromised certificates. If not provided,
+        /// uses crls_pem from the configuration file if present.
+        #[arg(long("crls"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+    },
+
+    #[command(
+        about = "Lookup a peer in the DHT via gateways",
+        long_about = indoc!{"
+            Connects to configured gateways and performs a DHT lookup for the given PeerID.
+            Prints the routing table information (closest peers, addresses) found.
+        "}
+    )]
+    #[serde(untagged)]
+    Lookup {
+        /// The PeerID to lookup
+        #[arg(index = 1)]
+        peer_id: PeerId,
+
+        /// Path to the configuration file
+        #[arg(
+            short,
+            long("config"),
+            default_value = "config.toml",
+            verbatim_doc_comment
+        )]
+        config_file: PathBuf,
+
+        /// Gateway addresses to connect to (repeatable, overrides config)
+        ///
+        /// Gateways provide network bootstrapping, DHT access, and optional relay.
+        ///
+        /// Examples:
+        ///   --gateway /ip4/203.0.113.10/tcp/8080/
+        ///   --gateway /dns4/gateway.hypha.example/tcp/443/
+        #[arg(long("gateway"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
+        /// Path to the certificate PEM file (overrides config)
+        ///
+        /// Must be a valid X.509 certificate in PEM format. If not provided, uses
+        /// cert_pem from the configuration file.
+        #[arg(long("cert"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key PEM file (overrides config)
+        ///
+        /// Must correspond to the certificate. If not provided, uses key_pem from
+        /// the configuration file.
+        ///
+        /// SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+        #[arg(long("key"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust chain PEM file (overrides config)
+        ///
+        /// CA bundle containing certificates trusted by this node. If not provided,
+        /// uses trust_pem from the configuration file.
+        #[arg(long("trust"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list PEM (overrides config)
+        ///
+        /// Optional CRL for rejecting compromised certificates. If not provided,
+        /// uses crls_pem from the configuration file if present.
+        #[arg(long("crls"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+    },
+
+    #[command(
+        about = "Derive PeerID from a certificate file",
+        long_about = indoc!{"
+            Reads an X.509 certificate or private key PEM file and prints the corresponding
+            libp2p PeerID.
+        "}
+    )]
+    #[serde(untagged)]
+    CertInfo {
+        /// Path to the PEM file (certificate or private key)
+        #[arg(index = 1, verbatim_doc_comment)]
+        path: PathBuf,
+    },
+    #[command(
+        about = "Generate a default configuration file",
+        long_about = indoc!{"
+            Generate a default configuration file
+
+            Creates a TOML configuration file with sensible defaults.
+        "}
+    )]
+    #[serde(untagged)]
+    Init {
+        /// Path where the configuration file will be written
+        #[clap(short, long, default_value = "config.toml", verbatim_doc_comment)]
+        output: PathBuf,
+
+        /// Gateway addresses to connect to (repeatable, overrides config)
+        ///
+        /// Gateways provide network bootstrapping, DHT access, and optional relay.
+        ///
+        /// Examples:
+        ///   --gateway /ip4/203.0.113.10/tcp/8080/
+        ///   --gateway /dns4/gateway.hypha.example/tcp/443/
+        #[arg(long("gateway"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gateway_addresses: Option<Vec<Multiaddr>>,
+
+        /// Path to the certificate PEM file (overrides config)
+        ///
+        /// Must be a valid X.509 certificate in PEM format. If not provided, uses
+        /// cert_pem from the configuration file.
+        #[arg(long("cert"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cert_pem: Option<PathBuf>,
+
+        /// Path to the private key PEM file (overrides config)
+        ///
+        /// Must correspond to the certificate. If not provided, uses key_pem from
+        /// the configuration file.
+        ///
+        /// SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+        #[arg(long("key"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_pem: Option<PathBuf>,
+
+        /// Path to the trust chain PEM file (overrides config)
+        ///
+        /// CA bundle containing certificates trusted by this node. If not provided,
+        /// uses trust_pem from the configuration file.
+        #[arg(long("trust"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trust_pem: Option<PathBuf>,
+
+        /// Path to the certificate revocation list PEM (overrides config)
+        ///
+        /// Optional CRL for rejecting compromised certificates. If not provided,
+        /// uses crls_pem from the configuration file if present.
+        #[arg(long("crls"), verbatim_doc_comment)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        crls_pem: Option<PathBuf>,
+    },
+}

--- a/crates/inspect/src/config.rs
+++ b/crates/inspect/src/config.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+
+use documented::{Documented, DocumentedFieldsOpt};
+use hypha_config::{ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use libp2p::Multiaddr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Documented, DocumentedFieldsOpt)]
+/// Inspector configuration for network diagnostics and introspection.
+pub struct Config {
+    /// Path to the TLS certificate PEM file.
+    ///
+    /// Must be a valid X.509 certificate in PEM format that establishes the inspector's
+    /// identity when connecting to Hypha gateways.
+    ///
+    /// SECURITY: Use certificates from a recognized CA or internal PKI for deployments.
+    cert_pem: PathBuf,
+
+    /// Path to the private key PEM file.
+    ///
+    /// Must correspond to cert_pem. This is the inspector's cryptographic identity.
+    ///
+    /// SECURITY:
+    ///   * Restrict file permissions (chmod 600 recommended)
+    ///   * Never commit to version control
+    ///   * Store securely using secrets management systems in production
+    ///   * Keep encrypted backups for recovery
+    key_pem: PathBuf,
+
+    /// Path to the trust chain PEM file (CA bundle).
+    ///
+    /// Contains root and intermediate certificates trusted by the inspector. Peers presenting
+    /// certificates signed by these CAs will be accepted for network connections.
+    trust_pem: PathBuf,
+
+    /// Path to certificate revocation list PEM (optional).
+    ///
+    /// Lists certificates that should no longer be trusted, even if they appear in the trust
+    /// chain (e.g., compromised or retired peers).
+    ///
+    /// SECURITY: Keep this updated from your certificate authority to maintain security.
+    crls_pem: Option<PathBuf>,
+
+    /// Gateway addresses to connect to (required for network entry).
+    ///
+    /// Specifies one or more gateways for network bootstrapping and relay functionality.
+    /// Multiple gateways improve redundancy; the inspector attempts to connect to all
+    /// configured peers, succeeding if any are reachable.
+    ///
+    /// Examples:
+    /// * "/ip4/203.0.113.10/tcp/8080/"
+    /// * "/dns4/gateway.hypha.example/tcp/443/"
+    ///
+    /// NOTE: Defaults to placeholder addresses so users must configure real endpoints.
+    #[serde(alias = "gateways")]
+    gateway_addresses: Vec<Multiaddr>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            cert_pem: PathBuf::from("inspect-cert.pem"),
+            key_pem: PathBuf::from("inspect-key.pem"),
+            trust_pem: PathBuf::from("inspect-trust.pem"),
+            crls_pem: None,
+            gateway_addresses: vec![
+                "/ip4/1.2.3.4/tcp/1234"
+                    .parse()
+                    .expect("default address parses into a Multiaddr"),
+                "/ip4/1.2.3.5/udp/1234/quic-v1"
+                    .parse()
+                    .expect("default address parses into a Multiaddr"),
+            ],
+        }
+    }
+}
+
+impl Config {
+    pub fn gateway_addresses(&self) -> &Vec<Multiaddr> {
+        &self.gateway_addresses
+    }
+}
+
+impl TLSConfig for Config {
+    fn cert_pem_path(&self) -> &std::path::Path {
+        &self.cert_pem
+    }
+
+    fn key_pem_path(&self) -> &std::path::Path {
+        &self.key_pem
+    }
+
+    fn trust_pem_path(&self) -> &std::path::Path {
+        &self.trust_pem
+    }
+
+    fn crls_pem_path(&self) -> Option<&std::path::Path> {
+        self.crls_pem.as_deref()
+    }
+}
+
+impl ValidatableConfig for Config {
+    fn validate(
+        _cfg: &ConfigWithMetadata<Self>,
+    ) -> std::result::Result<(), hypha_config::ConfigError> {
+        Ok(())
+    }
+}

--- a/crates/inspect/src/lib.rs
+++ b/crates/inspect/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod network;

--- a/crates/inspect/src/network.rs
+++ b/crates/inspect/src/network.rs
@@ -1,0 +1,299 @@
+use std::{collections::HashMap, sync::Arc};
+
+use futures_util::stream::StreamExt;
+use hypha_network::{
+    CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
+    dial::{DialAction, DialDriver, DialInterface, PendingDials},
+    external_address::{ExternalAddressAction, ExternalAddressDriver, ExternalAddressInterface},
+    kad::{KademliaAction, KademliaBehavior, KademliaDriver, KademliaInterface, PendingQueries},
+    listen::{ListenAction, ListenDriver, ListenInterface, PendingListens},
+    request_response::{
+        OutboundRequests, OutboundResponses, RequestHandler, RequestResponseAction,
+        RequestResponseBehaviour, RequestResponseDriver, RequestResponseError,
+        RequestResponseInterface,
+    },
+    swarm::{SwarmDriver, SwarmError},
+};
+use libp2p::{
+    StreamProtocol, Swarm, SwarmBuilder, identify, kad, ping, request_response,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, tls, yamux,
+};
+use tokio::sync::{SetOnce, mpsc};
+
+#[derive(Clone)]
+pub struct Network {
+    action_sender: mpsc::Sender<Action>,
+}
+
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    ping: ping::Behaviour,
+    identify: identify::Behaviour,
+    kademlia: kad::Behaviour<kad::store::MemoryStore>,
+    health_request_response: request_response::Behaviour<HealthCodec>,
+}
+
+pub struct NetworkDriver {
+    swarm: Swarm<Behaviour>,
+    pending_dials_map: PendingDials,
+    pending_listen_map: PendingListens,
+    pending_queries_map: PendingQueries,
+    pending_bootstrap: Arc<SetOnce<()>>,
+    action_receiver: mpsc::Receiver<Action>,
+    health_outbound_requests_map: OutboundRequests<HealthCodec>,
+    health_outbound_responses_map: OutboundResponses,
+    health_request_handlers: Vec<RequestHandler<HealthCodec>>,
+    exclude_cidrs: Vec<IpNet>,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum Action {
+    Dial(DialAction),
+    Listen(ListenAction),
+    Kademlia(KademliaAction),
+    ExternalAddress(ExternalAddressAction),
+    HealthRequestResponse(RequestResponseAction<HealthCodec>),
+}
+
+type HealthCodec = hypha_messages::health::Codec;
+
+impl Network {
+    pub fn create(
+        cert_chain: Vec<CertificateDer<'static>>,
+        private_key: PrivateKeyDer<'static>,
+        ca_certs: Vec<CertificateDer<'static>>,
+        crls: Vec<CertificateRevocationListDer<'static>>,
+        exclude_cidrs: Vec<IpNet>,
+    ) -> Result<(Self, NetworkDriver), SwarmError> {
+        let (action_sender, action_receiver) = mpsc::channel(5);
+
+        let mut swarm =
+            SwarmBuilder::with_existing_identity(cert_chain, private_key, ca_certs, crls)
+                .with_tokio()
+                .with_tcp(
+                    tcp::Config::default(),
+                    tls::Config::new,
+                    yamux::Config::default,
+                )
+                .map_err(|_| {
+                    SwarmError::TransportConfig("Failed to create TCP transport.".to_string())
+                })?
+                .with_quic()
+                .with_dns()
+                .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
+                .with_behaviour(|key| Behaviour {
+                    ping: ping::Behaviour::new(ping::Config::new()),
+                    identify: identify::Behaviour::new(identify::Config::new(
+                        "/hypha-identify/0.0.1".to_string(),
+                        key.public(),
+                    )),
+                    kademlia: kad::Behaviour::new(
+                        key.public().to_peer_id(),
+                        kad::store::MemoryStore::new(key.public().to_peer_id()),
+                    ),
+                    health_request_response: request_response::Behaviour::<HealthCodec>::new(
+                        [(
+                            StreamProtocol::new(hypha_messages::health::IDENTIFIER),
+                            request_response::ProtocolSupport::Outbound,
+                        )],
+                        request_response::Config::default(),
+                    ),
+                })
+                .map_err(|_| {
+                    SwarmError::BehaviourCreation("Failed to create swarm behavior.".to_string())
+                })?
+                // TODO: Tune swarm configuration
+                .with_swarm_config(|config| config)
+                .build();
+
+        swarm
+            .behaviour_mut()
+            .kademlia
+            .set_mode(Some(kad::Mode::Client));
+
+        Ok((
+            Network { action_sender },
+            NetworkDriver {
+                swarm,
+                pending_dials_map: HashMap::default(),
+                pending_listen_map: HashMap::default(),
+                pending_queries_map: HashMap::default(),
+                pending_bootstrap: Arc::new(SetOnce::new()),
+                health_outbound_requests_map: HashMap::default(),
+                health_outbound_responses_map: HashMap::default(),
+                health_request_handlers: Vec::new(),
+                action_receiver,
+                exclude_cidrs,
+            },
+        ))
+    }
+}
+
+impl SwarmDriver<Behaviour> for NetworkDriver {
+    async fn run(mut self) -> Result<(), SwarmError> {
+        loop {
+            tokio::select! {
+                event = self.swarm.select_next_some() => {
+                    match event {
+                        SwarmEvent::ConnectionEstablished { connection_id, peer_id, .. } => {
+                            self.process_connection_established(peer_id, &connection_id).await;
+                        }
+                        SwarmEvent::OutgoingConnectionError { connection_id, error, .. } => {
+                            self.process_connection_error(&connection_id, error).await;
+                        }
+                        SwarmEvent::NewListenAddr { listener_id, address } => {
+                            self.process_new_listen_addr(&listener_id, address).await;
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Identify(event)) => {
+                            self.process_identify_event(event);
+                        }
+                        SwarmEvent::Behaviour(BehaviourEvent::Kademlia(kad::Event::OutboundQueryProgressed {id,  result, step, ..})) => {
+                            self.process_kademlia_query_result(id, result, step).await;
+                         }
+                        SwarmEvent::Behaviour(BehaviourEvent::HealthRequestResponse(event)) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, HealthCodec>>::process_request_response_event(&mut self, event).await;
+                        }
+                        _ => {
+                            tracing::debug!("Unhandled event: {:?}", event);
+                        }
+                    }
+                },
+                Some(action) = self.action_receiver.recv() => {
+                    match action {
+                        Action::Dial(action) => {
+                            self.process_dial_action(action).await;
+                        },
+                        Action::Listen(action) => { self.process_listen_action(action).await; },
+                        Action::Kademlia(action) => { self.process_kademlia_action(action).await; },
+                        Action::ExternalAddress(action) => {
+                            self.process_external_address_action(action).await;
+                        }
+                        Action::HealthRequestResponse(action) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, HealthCodec>>::process_request_response_action(&mut self, action).await;
+                        }
+                    }
+                }
+                else => break
+            }
+        }
+
+        Ok(())
+    }
+
+    fn swarm(&mut self) -> &mut Swarm<Behaviour> {
+        &mut self.swarm
+    }
+}
+
+impl DialInterface for Network {
+    async fn send(&self, action: DialAction) {
+        self.action_sender
+            .send(Action::Dial(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}
+
+impl DialDriver<Behaviour> for NetworkDriver {
+    fn pending_dials(&mut self) -> &mut PendingDials {
+        &mut self.pending_dials_map
+    }
+
+    fn exclude_cidrs(&self) -> &[IpNet] {
+        &self.exclude_cidrs
+    }
+}
+
+impl ListenInterface for Network {
+    async fn send(&self, action: ListenAction) {
+        self.action_sender
+            .send(Action::Listen(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}
+
+impl ListenDriver<Behaviour> for NetworkDriver {
+    fn pending_listens(&mut self) -> &mut PendingListens {
+        &mut self.pending_listen_map
+    }
+}
+
+impl ExternalAddressDriver<Behaviour> for NetworkDriver {}
+
+impl ExternalAddressInterface for Network {
+    async fn send(&self, action: ExternalAddressAction) {
+        self.action_sender
+            .send(Action::ExternalAddress(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}
+
+impl RequestResponseBehaviour<HealthCodec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<HealthCodec> {
+        &mut self.health_request_response
+    }
+}
+
+impl RequestResponseDriver<Behaviour, HealthCodec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<HealthCodec> {
+        &mut self.health_outbound_requests_map
+    }
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses {
+        &mut self.health_outbound_responses_map
+    }
+
+    fn request_handlers(&mut self) -> &mut Vec<RequestHandler<HealthCodec>> {
+        &mut self.health_request_handlers
+    }
+}
+
+impl RequestResponseInterface<HealthCodec> for Network {
+    async fn send(&self, action: RequestResponseAction<HealthCodec>) {
+        self.action_sender
+            .send(Action::HealthRequestResponse(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+
+    fn try_send(
+        &self,
+        action: RequestResponseAction<HealthCodec>,
+    ) -> Result<(), RequestResponseError> {
+        self.action_sender
+            .try_send(Action::HealthRequestResponse(action))
+            .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
+    }
+}
+
+impl KademliaBehavior for Behaviour {
+    fn kademlia(&mut self) -> &mut kad::Behaviour<kad::store::MemoryStore> {
+        &mut self.kademlia
+    }
+}
+
+impl KademliaDriver<Behaviour> for NetworkDriver {
+    fn pending_queries(&mut self) -> &mut PendingQueries {
+        &mut self.pending_queries_map
+    }
+
+    fn pending_bootstrap(&mut self) -> &mut Arc<SetOnce<()>> {
+        &mut self.pending_bootstrap
+    }
+
+    fn exclude_cidrs(&self) -> Vec<IpNet> {
+        self.exclude_cidrs.clone()
+    }
+}
+
+impl KademliaInterface for Network {
+    async fn send(&self, action: KademliaAction) {
+        self.action_sender
+            .send(Action::Kademlia(action))
+            .await
+            .expect("network driver should be running and able to receive actions");
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Hypha Documentation
+
+This directory contains the source code for the Hypha documentation website, built using [Zola](https://www.getzola.org/).
+
+## Prerequisites
+
+You need to install **Zola** to build and serve the documentation locally.
+
+Please refer to the official Zola documentation for installation instructions for your operating system:
+[https://www.getzola.org/documentation/getting-started/installation/](https://www.getzola.org/documentation/getting-started/installation/)
+
+## Running Locally
+
+To serve the documentation locally with live reload, run the following command from the repository root:
+
+```bash
+zola --root docs serve
+```
+
+Alternatively, you can navigate into the `docs` directory and run:
+
+```bash
+cd docs
+zola serve
+```
+
+The site will be available at `http://127.0.0.1:1111` by default.

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -12,5 +12,7 @@ index_format = "fuse_javascript"
 [markdown]
 highlight_code = true
 
+github_alerts = true
+
 [extra]
 # Put all your custom variables here

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -11,6 +11,8 @@ index_format = "fuse_javascript"
 
 [markdown]
 highlight_code = true
+highlight_theme = "one-dark"
+extra_syntaxes_and_themes = ["syntaxes"]
 
 render_emoji = true
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -12,6 +12,14 @@ index_format = "fuse_javascript"
 [markdown]
 highlight_code = true
 
+render_emoji = true
+
+external_links_target_blank = true
+external_links_no_follow = true
+external_links_no_referrer = true
+
+bottom_footnotes = true
+
 github_alerts = true
 
 [extra]

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -32,6 +32,7 @@ installing to ~/.local/bin
   hypha-data
   hypha-scheduler
   hypha-certutil
+  hypha-inspect
 everything's installed!
 ```
 For a list of available versions, visit the [GitHub Releases](https://github.com/hypha-space/hypha/releases) page.
@@ -55,7 +56,8 @@ cargo install --git https://github.com/hypha-space/hypha \
     hypha-data \
     hypha-gateway \
     hypha-scheduler \
-    hypha-worker
+    hypha-worker \
+    hypha-inspect
 ```
 
 > [!NOTE]
@@ -70,7 +72,8 @@ rm -f ~/.local/bin/hypha-certutil \
     ~/.local/bin/hypha-data \
     ~/.local/bin/hypha-gateway \
     ~/.local/bin/hypha-scheduler \
-    ~/.local/bin/hypha-worker
+    ~/.local/bin/hypha-worker \
+    ~/.local/bin/hypha-inspect
 ```
 
 ## Next steps

--- a/docs/content/reference/hypha-inspect-cli.md
+++ b/docs/content/reference/hypha-inspect-cli.md
@@ -1,0 +1,181 @@
++++
+title = "hypha-inspect CLI"
+description = "Auto-generated reference for the hypha-inspect command, covering configuration and operational subcommands."
+[taxonomies]
+track = ["reference"]
++++
+
+<!-- NOTE: Auto-generated. Do not edit manually. -->
+
+# hypha-inspect CLI Reference
+
+This document contains the help content for the `hypha-inspect` command-line program.
+
+**Command Overview:**
+
+* [`hypha-inspect`↴](#hypha-inspect)
+* [`hypha-inspect probe`↴](#hypha-inspect-probe)
+* [`hypha-inspect lookup`↴](#hypha-inspect-lookup)
+* [`hypha-inspect cert-info`↴](#hypha-inspect-cert-info)
+* [`hypha-inspect init`↴](#hypha-inspect-init)
+
+## `hypha-inspect`
+
+Hypha Inspect is a CLI tool for diagnosing network connectivity,
+inspecting routing tables, and verifying identities within the Hypha network.
+
+
+**Usage:** `hypha-inspect <COMMAND>`
+
+###### **Subcommands:**
+
+* `probe` — Check if a remote peer is healthy and reachable
+* `lookup` — Lookup a peer in the DHT via gateways
+* `cert-info` — Derive PeerID from a certificate file
+* `init` — Generate a default configuration file
+
+
+
+## `hypha-inspect probe`
+
+Connects to the specified multiaddr and performs a health check.
+
+In verbose mode, prints detailed routing information and connection stats.
+
+
+**Usage:** `hypha-inspect probe [OPTIONS] <ADDRESS>`
+
+###### **Arguments:**
+
+* `<ADDRESS>` — Target peer multiaddr to probe
+
+###### **Options:**
+
+* `-c`, `--config <CONFIG_FILE>` — Path to the configuration file
+
+  Default value: `config.toml`
+* `--timeout <TIMEOUT>` — Maximum time to wait for health response (milliseconds)
+
+   If the peer doesn't respond within this duration, the probe fails.
+   Increase for high-latency networks or overloaded peers.
+
+  Default value: `2000`
+* `--cert <CERT_PEM>` — Path to the certificate PEM file (overrides config)
+
+   Must be a valid X.509 certificate in PEM format. If not provided, uses
+   cert_pem from the configuration file.
+* `--key <KEY_PEM>` — Path to the private key PEM file (overrides config)
+
+   Must correspond to the certificate. If not provided, uses key_pem from
+   the configuration file.
+
+   SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+* `--trust <TRUST_PEM>` — Path to the trust chain PEM file (overrides config)
+
+   CA bundle containing certificates trusted by this node. If not provided,
+   uses trust_pem from the configuration file.
+* `--crls <CRLS_PEM>` — Path to the certificate revocation list PEM (overrides config)
+
+   Optional CRL for rejecting compromised certificates. If not provided,
+   uses crls_pem from the configuration file if present.
+
+
+
+## `hypha-inspect lookup`
+
+Connects to configured gateways and performs a DHT lookup for the given PeerID.
+Prints the routing table information (closest peers, addresses) found.
+
+
+**Usage:** `hypha-inspect lookup [OPTIONS] <PEER_ID>`
+
+###### **Arguments:**
+
+* `<PEER_ID>` — The PeerID to lookup
+
+###### **Options:**
+
+* `-c`, `--config <CONFIG_FILE>` — Path to the configuration file
+
+  Default value: `config.toml`
+* `--gateway <GATEWAY_ADDRESSES>` — Gateway addresses to connect to (repeatable, overrides config)
+
+   Gateways provide network bootstrapping, DHT access, and optional relay.
+
+   Examples:
+     --gateway /ip4/203.0.113.10/tcp/8080/
+     --gateway /dns4/gateway.hypha.example/tcp/443/
+* `--cert <CERT_PEM>` — Path to the certificate PEM file (overrides config)
+
+   Must be a valid X.509 certificate in PEM format. If not provided, uses
+   cert_pem from the configuration file.
+* `--key <KEY_PEM>` — Path to the private key PEM file (overrides config)
+
+   Must correspond to the certificate. If not provided, uses key_pem from
+   the configuration file.
+
+   SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+* `--trust <TRUST_PEM>` — Path to the trust chain PEM file (overrides config)
+
+   CA bundle containing certificates trusted by this node. If not provided,
+   uses trust_pem from the configuration file.
+* `--crls <CRLS_PEM>` — Path to the certificate revocation list PEM (overrides config)
+
+   Optional CRL for rejecting compromised certificates. If not provided,
+   uses crls_pem from the configuration file if present.
+
+
+
+## `hypha-inspect cert-info`
+
+Reads an X.509 certificate or private key PEM file and prints the corresponding
+libp2p PeerID.
+
+
+**Usage:** `hypha-inspect cert-info <PATH>`
+
+###### **Arguments:**
+
+* `<PATH>` — Path to the PEM file (certificate or private key)
+
+
+
+## `hypha-inspect init`
+
+Generate a default configuration file
+
+Creates a TOML configuration file with sensible defaults.
+
+
+**Usage:** `hypha-inspect init [OPTIONS]`
+
+###### **Options:**
+
+* `-o`, `--output <OUTPUT>` — Path where the configuration file will be written
+
+  Default value: `config.toml`
+* `--gateway <GATEWAY_ADDRESSES>` — Gateway addresses to connect to (repeatable, overrides config)
+
+   Gateways provide network bootstrapping, DHT access, and optional relay.
+
+   Examples:
+     --gateway /ip4/203.0.113.10/tcp/8080/
+     --gateway /dns4/gateway.hypha.example/tcp/443/
+* `--cert <CERT_PEM>` — Path to the certificate PEM file (overrides config)
+
+   Must be a valid X.509 certificate in PEM format. If not provided, uses
+   cert_pem from the configuration file.
+* `--key <KEY_PEM>` — Path to the private key PEM file (overrides config)
+
+   Must correspond to the certificate. If not provided, uses key_pem from
+   the configuration file.
+
+   SECURITY: Ensure this file has restricted permissions (e.g., chmod 600).
+* `--trust <TRUST_PEM>` — Path to the trust chain PEM file (overrides config)
+
+   CA bundle containing certificates trusted by this node. If not provided,
+   uses trust_pem from the configuration file.
+* `--crls <CRLS_PEM>` — Path to the certificate revocation list PEM (overrides config)
+
+   Optional CRL for rejecting compromised certificates. If not provided,
+   uses crls_pem from the configuration file if present.

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -8,19 +8,125 @@ track = ["reference"]
 
 # Troubleshooting
 
-This guide addresses common issues encountered when using Hypha. Follow the steps for each error to resolve them effectively.
+Something not working? This guide helps you diagnose issues, verify your setup, and find fixes for problems others have encountered. Work through the tools below to gather evidence, then match your symptoms to known failure signatures—or open an issue if you hit something new.
 
-For better navigation, the guide is structured by component.
+> [!TIP]
+> If you're still provisioning a new environment, complete the [Quick Start](../quickstart.md) first so the baseline configuration is correct before diving into debugging.
 
-## Gateway
+## Troubleshooting Tools
 
-## Worker
+Before chasing errors, use these tools to understand what's happening and verify that nodes can actually reach each other.
 
-### Snappy Corrupt Input
+### Control log verbosity with `RUST_LOG`
 
-When starting a training and a Worker fails immediately with the following message:
+Set the `RUST_LOG` environment variable when you start a Hypha binary to raise or reduce noise per module.
 
-```LOG
+```bash
+# hypha-worker will emit debug logs while QUIC transport stays at info
+RUST_LOG=hypha_worker=debug,libp2p_quic=info hypha-worker --config worker.toml
+```
+```log
+2025-11-27T12:15:46.111Z DEBUG hypha_worker::executor::bridge requesting data slice index from scheduler
+2025-11-27T12:15:46.219Z  INFO hypha_worker::executor::bridge copied resource size=268435456 file=/tmp/hypha/artifacts/0
+```
+
+Adjust the comma-separated filter for each crate (`hypha_gateway`, `hypha_scheduler`, `hypha_data`, etc.) to isolate the subsystem that is misbehaving. Use `trace` only temporarily; it may capture sensitive payload details and bloats log volume.
+
+### Capture telemetry with OpenTelemetry (OTEL)
+
+Centralizing logs and traces removes guesswork when multiple peers interact. Run a collector (e.g., Grafana Cloud OTLP endpoint, or a local collector) and point each Hypha binary at it via the standard `OTEL_*` variables or the respective configuration options.
+
+Start a local collector (replace image/tag as needed):
+```bash
+docker run --rm -p 4317:4317 otel/opentelemetry-collector-contrib:0.140.0
+```
+
+Now, configure Hypha to export spans and metrics to the collector and then start Hypha as usual:
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+export OTEL_SERVICE_NAME="worker-lab-01"
+export OTEL_RESOURCE_ATTRIBUTES="service.namespace=lab,deployment.environment=staging"
+
+hypha-worker --config worker.toml
+```
+
+> [!WARNING]
+> Telemetry payloads contain peer IDs and certificate fingerprints. Only forward OTLP data to collectors that enforce encryption.
+
+For hosted collectors (Grafana Cloud, AWS OTEL, etc.), reuse the same environment variables but update `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_EXPORTER_OTLP_PROTOCOL` according to the provider. Keep the service name unique per node so traces from the gateway, scheduler, workers, and data nodes remain distinguishable.
+
+### Inspect the public IP that peers advertise
+
+Mismatched public IPs lead to relay loops and errors. Confirm what the Internet sees before editing `exclude_cidr` or firewall rules.
+
+```bash
+curl https://1.1.1.1/cdn-cgi/trace/ | grep ip=
+```
+```text
+ip=203.0.113.24
+```
+
+### Get a peer ID from a certificate
+
+The `hypha-inspect cert-info` command derives the libp2p PeerID from a certificate or private key file. Use it when you have a node's certificate but need its PeerID to look up its addresses or check logs.
+
+```bash
+hypha-inspect cert-info /path/to/node-cert.pem
+```
+```text
+PeerId: 12D3KooWExamplePeerId
+```
+
+A typical troubleshooting workflow: get the PeerID from a certificate, look up its advertised addresses in the DHT, then probe those addresses to verify connectivity.
+
+### Look up a peer in the DHT
+
+The `hypha-inspect lookup` command queries gateways to find a peer's advertised addresses in the DHT. This helps diagnose discovery issues—if a peer isn't in the DHT, other nodes can't find it.
+
+```bash
+hypha-inspect lookup --config worker.toml 12D3KooWExamplePeerId
+```
+```text
+PeerId: 12D3KooWExamplePeerId
+Addresses:
+  /ip4/203.0.113.10/udp/9000/quic-v1
+  /ip4/10.0.0.5/udp/9000/quic-v1
+```
+
+No results? The peer may not have successfully connected to a gateway, or its DHT records expired. Restart the peer and check its logs for gateway connection errors.
+
+### Probe a peer directly
+
+The `probe` command checks whether a remote peer is healthy and reachable. Pass any multiaddr from the lookup output—the peer ID suffix is optional.
+
+> [!NOTE]
+> All Hypha binaries (except `hypha-certutil`) include the `probe` subcommand. You can run `hypha-worker probe`, `hypha-gateway probe`, etc., whichever is already configured on the machine you're troubleshooting from.
+
+```bash
+hypha-inspect probe --config worker.toml /ip4/203.0.113.10/udp/9000/quic-v1
+```
+```text
+Peer 12D3KooWExamplePeerId is healthy (response time: 23ms)
+```
+
+If the probe fails, check firewall rules, confirm both nodes use certificates from the same trust chain, and verify the target peer is running.
+
+See also: [hypha-inspect CLI reference](../cli/hypha-inspect.md) for all available options.
+
+## Failure Signatures
+
+This section documents issues we've seen in the field—bugs that have since been fixed, common misconfigurations, and edge cases. Some entries simply require upgrading to a newer release; others need configuration changes on your end.
+
+If your error isn't listed here, please [open an issue](https://github.com/hypha-space/hypha/issues) with debug logs attached. Either we'll help you fix a misconfiguration, or you've found something new that we should address and document.
+
+### Snappy decompression failure
+
+```text
+cramjam.DecompressionError: snappy: corrupt input (expected valid offset but got offset 882; dst position: 0)
+```
+
+```log
 2025-11-26T09:38:35.115470Z  INFO hypha_worker::executor::bridge: Copied resource size=131 file=/tmp/hypha-df71010f-4977-41d2-a694-b4ffde3a590b/artifacts/0
 Traceback (most recent call last):
   File "/Users/test/.cache/uv/archive-v0/wu732xbcarPOjBnemLBfq/lib/python3.12/site-packages/snappy/snappy.py", line 84, in uncompress
@@ -29,26 +135,72 @@ Traceback (most recent call last):
 cramjam.DecompressionError: snappy: corrupt input (expected valid offset but got offset 882; dst position: 0)
 ```
 
+#### What this indicates
 
+- The worker fails immediately after starting a training task.
+- The logged `size=<value>` next to `hypha_worker::executor::bridge` shows the bytes Hypha copied from the dataset. A very small size (for example, `size=131`) usually means Git LFS pointers were synced instead of the real files.
+- If the copied size matches the real dataset file size, the artifacts are likely compressed with the wrong codec.
 
-#### Solution A
+#### How to fix it
 
-Make sure that the dataset was successfuly downloaded. A `size=131` is an indicator that the cloning a dataset from a repositry only cloned the `LFS pointer` and not the actuall files. To verify this use `cat <file_in_repo>`. If the content is similar to this:
+1. **Confirm the dataset fully downloaded.** Run `cat <file>` in the dataset repository. If the output looks like a Git LFS pointer (starts with `version https://git-lfs.github.com/spec/v1`), delete the repo, install/configure `git lfs`, and clone again so the binary artifacts download instead of pointers.
+2. **Verify compression format.** When the logged `size` matches the on-disk dataset file size, ensure every dataset file is compressed with [Snappy](https://github.com/google/snappy). Recompress offending files and re-upload them before retrying the training run.
 
+See also: [Training guide](../training.md) for dataset packaging and [Worker reference](../worker.md) for artifact mounting paths.
+
+### GLIBC version mismatch
+
+```text
+hypha-gateway: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by hypha-gateway)
 ```
-version https://git-lfs.github.com/spec/v1
-oid sha256:63ecc7d8cd62fef16d3d6c50463644fa81dd9d92506bc9ca7a8f4fdb58579d8a
-size 14851
+```text
+hypha-gateway: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by hypha-gateway)
 ```
 
-Then remove the repository, ensure that `git lfs`  is installed and clone the dataset again.
+#### What this indicates
 
-#### Solution B
+- You are running a Hypha build that dynamically links against glibc 2.38, but the host OS ships an older glibc.
+- These binaries were produced before we switched to statically linked MUSL builds, so they only work on recent distributions.
 
-If the `size` indicated in the `hypha_worker::executor::bridge` message, matches the size of the file in the dataset, make sure that all files in the dataset are compressed with [Snappy](https://github.com/google/snappy).
+#### How to fix it
 
-## Data
+1. **Upgrade Hypha to alpha.17 or newer.** Starting with `v1.0.0-alpha.17`, all Linux releases are built with MUSL and statically linked.
 
-## Cert-Util
+See also: [Installation](../installation.md) for supported platforms and package formats.
 
-## AIM
+### Relay circuit exhaustion
+
+**Worker Logs (captured with RUST_LOG=debug)**
+```log
+2025-11-27 11:34:25.325 error bridge error: network
+2025-11-27 11:34:25.325 error Outbound request-response failure
+2025-11-27 11:34:25.324 debug Closed connection
+2025-11-27 11:34:25.324 debug Peer disconnected
+2025-11-27 11:34:25.324 debug Connection closed with error IO(Custom { kind: Other, error: Custom { kind: Other, error: Error(Right(Decode(Io(Custom { kind: UnexpectedEof, error: "peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof" })))) } }): Connected { endpoint: Listener { local_addr: /ip4/92.63.156.142/udp/55001/quic-v1/p2p-circuit, send_back_addr: /p2p/12D3KooWJfDWPLaH5Nh2qkD4JJkTYmAyDeNtZVtuo7LkTXRJfPce }, peer_id: PeerId("12D3KooWJfDWPLaH5Nh2qkD4JJkTYmAyDeNtZVtuo7LkTXRJfPce") }
+...
+2025-11-27 11:34:24.787 debug ffc4ce71: new outbound (Stream ffc4ce71/420) of (Connection ffc4ce71 Server (streams 4))
+2025-11-27 11:34:24.786 debug Requesting data slice index from scheduler
+``` 
+
+**Gateway Logs (captured with RUST_LOG=debug)**
+```log
+2025-11-27 11:34:25.393 debug Unhandled event: Behaviour(BehaviourEvent: CircuitClosed { src_peer_id: PeerId("12D3KooWJfDWPLaH5Nh2qkD4JJkTYmAyDeNtZVtuo7LkTXRJfPce"), dst_peer_id: PeerId("12D3KooWRrp64o43d3CQovjUT52ojtNUTtkUpJ4wSd9CfyZjkRqp"), error: Some(Custom { kind: Other, error: "Max circuit bytes reached." }) })
+2025-11-27 11:34:24.408 debug Unhandled event: Behaviour(BehaviourEvent: Event { peer: PeerId("12D3KooWJfDWPLaH5Nh2qkD4JJkTYmAyDeNtZVtuo7LkTXRJfPce"), connection: ConnectionId(7), result: Ok(23.343316ms) })
+```
+
+#### What this indicates
+
+- The worker asks the scheduler for the next data slice, opens a stream through the gateway, and the connection closes before the transfer completes.
+- Debug logs (enable with `RUST_LOG=debug` or use OpenTelemetry) show the gateway closing a `p2p-circuit` relay because the `max circuit bytes` limit was reached.
+- This happens when peers cannot establish a direct path and large amounts of data are forced over the gateway. Common causes:
+  - Multiple nodes on the same host or LAN without allowing the respective ranges in `exclude_cidr`
+  - Firewall rules blocking direct peer connections
+  - NAT traversal (DCUtR) failing silently
+
+#### How to fix it
+
+1. **Allow direct LAN/localhost connectivity.** Update each node's `exclude_cidr` so the relevant private ranges or `127.0.0.1` addresses are advertised, and ensure every peer listens on a unique port. See the [Multiple Nodes on Localhost or Private Network](../deploy/local_multi_node.md) guide for detailed steps.
+2. **Verify firewall/NAT rules.** Ensure workers, data nodes, and schedulers can reach each other directly or via DCUtR. Relays should only serve for DCUtR and as DHT anchors, not the primary channel for dataset transfers.
+3. **Monitor for residual relays.** With direct routes in place, you should no longer see `Max circuit bytes reached` events. If they persist, double-check that all peers restarted with the new configuration and that no infrastructure component forces traffic back through the gateway.
+
+See also: [Gateway reference](../gateway.md) for relay settings and [Worker reference](../worker.md) for `exclude_cidr` options.

--- a/docs/syntaxes/log.sublime-syntax
+++ b/docs/syntaxes/log.sublime-syntax
@@ -1,0 +1,60 @@
+%YAML 1.2
+---
+name: Log File
+
+file_extensions:
+  - log
+
+scope: log
+
+contexts:
+  main:
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:TRACE))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: support.constant.log
+        3: text.log
+
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:DEBUG))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: entity.name.function.log
+        3: text.log
+
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:INFO))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: string.other.log
+        3: text.log
+
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:WARN(?:ING)?))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: constant.numeric
+        3: text.log
+
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:ERROR))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: variable.language.log
+        3: text.log
+
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:CRITICAL))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: keyword.control.log
+        3: text.log
+
+    - match: '^(\[?\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\]?)?\s*((?i:FATAL))\b(.*)$'
+      captures:
+        1: comment.line.log
+        2: constant.language.log
+        3: text.log
+
+    - match: '([\w-]+)\.(?i:(DEBUG|INFO|WARNING|ERROR|CRITICAL)):'
+      captures:
+        1: constant.language.log
+        2: keyword.other.log
+
+    - match: '.+'
+      scope: text.log

--- a/docs/themes/hypha/static/css/hypha.css
+++ b/docs/themes/hypha/static/css/hypha.css
@@ -1,7 +1,14 @@
-:root {
+:root,
+:host {
     --pico-font-family: monospace;
     --pico-border-radius: 0.25rem;
     --hypha-max-width: 960px;
+
+    --hypha-color-note: #0172ad;
+    --hypha-color-tip: #007a50;
+    --hypha-color-important: #524ed2;
+    --hypha-color-warning: #ffbf00;
+    --hypha-color-caution: #c52f21;
 }
 
 header {
@@ -37,4 +44,59 @@ main ul[role="navigation"] li summary {
 footer {
     border-top: 1px solid var(--pico-color);
     font-size: 90%;
+}
+
+blockquote {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
+.markdown-alert-note {
+    border-color: var(--hypha-color-note);
+}
+.markdown-alert-note::before {
+    display: block;
+    content: "NOTE";
+    margin-bottom: var(--pico-spacing);
+    color: var(--hypha-color-note);
+}
+
+.markdown-alert-tip {
+    border-color: var(--hypha-color-tip);
+}
+.markdown-alert-tip::before {
+    display: block;
+    content: "TIP";
+    margin-bottom: var(--pico-spacing);
+    color: var(--hypha-color-tip);
+}
+
+.markdown-alert-important {
+    border-color: var(--hypha-color-important);
+}
+.markdown-alert-important::before {
+    display: block;
+    content: "IMPORTANT";
+    margin-bottom: var(--pico-spacing);
+    color: var(--hypha-color-important);
+}
+
+.markdown-alert-warning {
+    border-color: var(--hypha-color-warning);
+}
+.markdown-alert-warning::before {
+    display: block;
+    content: "WARNING";
+    margin-bottom: var(--pico-spacing);
+    color: var(--hypha-color-warning);
+}
+
+.markdown-alert-caution {
+    border-color: var(--hypha-color-caution);
+}
+.markdown-alert-caution::before {
+    display: block;
+    content: "CAUTION";
+    margin-bottom: var(--pico-spacing);
+    color: var(--hypha-color-caution);
 }

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ set -u
 
 APP_NAME="hypha"
 VERSION=""
-BINARIES="hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil"
+BINARIES="hypha-gateway hypha-worker hypha-data hypha-scheduler hypha-certutil hypha-inspect"
 
 if [ -n "${HYPHA_INSTALLER_BASE_URL:-}" ]; then
     INSTALLER_BASE_URL="$HYPHA_INSTALLER_BASE_URL"


### PR DESCRIPTION
This PR introduces a CLI to inspect a Hypha network, e.g. lookup a peer in the DHT.

![inspect cli](https://github.com/user-attachments/assets/69d93bfb-5e37-4ac7-8d4c-f81971bd9c61)

Along with an update of the troubleshooting guide to document how to collect evidence and more failure cases to improve the overall trouble shooting experience. This includes updates on how the docs are rendered to make it easier to read the guide and other docs.

<img alt="Screenshot 2025-12-02 at 09-47-21 Troubleshooting · Hypha Docs" src="https://github.com/user-attachments/assets/969d3521-be53-4f2c-a1d9-e87d6c91252a" />
