### PR TITLE
chore: add Hypha issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,60 @@
+---
+name: Bug Report
+about: Report a failure, crash, or unexpected behavior in Hypha
+title: "Bug: "
+labels: 'bug'
+assignees: ''
+
+---
+
+## Description
+
+<!--
+Provide a concise summary of the bug.
+Example: "The worker node fails to fetch datasets larger than 5GB when using the TCP transport."
+-->
+
+## Symptoms
+
+<!--
+Describe what you see. Include error messages, crash logs, or unexpected state changes.
+
+Example:
+- The worker log shows `StreamReset(Code(1))` repeatedly.
+- `hypha-inspect probe` for /address/ times out.
+- The scheduler reports the worker lease as "expired".
+-->
+
+## Steps to Reproduce
+
+<!--
+Detailed description of all steps you took, so others can reproduce the issue.
+
+Example:
+1. Start a gateway using this config:
+    
+    ```toml
+    # Gateway config... 
+    ```
+2. Run a worker with `exclude_cidr = ["0.0.0.0/0"]`.
+3. Submit a training job with a 6GB dataset.
+4. Observe the worker logs.
+
+IMPORTANT: While you should be as detailed as possible, avoid including sensitive information such as tokens, private keys or IP addresses!
+-->
+
+## Evidence
+
+<!--
+Please share any evidence you have collected that helps us understand, reproduce, and triage this bug. We welcome any context you can provide.
+
+Examples:
+- Logs (Tip: `RUST_LOG=debug` often captures the right level of detail)
+- Environment: OS, Hypha version, deployment type (Local, Docker, Cloud).
+- Visuals: Screenshots, recordings, or diagrams.
+- Diagnostics: Output from `hypha-inspect lookup` or `probe`.
+
+Feel free to share whatever helps us see what you see! 
+
+IMPORTANT: Remember Github issues are public, so please do not include any sensitive information!
+-->

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,70 @@
+---
+name: Epic
+about: Track a significant feature, architectural change, or RFC implementation
+title: "Epic: "
+labels: 'epic'
+assignees: ''
+
+---
+
+## Summary
+
+<!--
+Provide a high-level overview of the initiative. What is this epic about?
+
+Example: "Implement Reinforcement Learning support for the Scheduler and Worker nodes, enabling distributed policy training across the Hypha network."
+-->
+
+## Motivation
+
+<!--
+Why is this initiative needed? What problem does it solve or what opportunity does it unlock?
+
+Please link to relevant context:
+- RFCs (e.g., `rfc/2025-06-04_decentralized_task_announcement_protocol.md`)
+- Architectural goals or design documents
+- User feedback or feature requests
+
+Example: "Data Scientists currently cannot train RL agents on Hypha. Supporting RL workloads would open Hypha to a new class of ML practitioners and enable distributed robotics research."
+-->
+
+## Key Goals
+
+<!--
+What specific outcomes must be achieved for this epic to be considered complete?
+
+Use checkboxes to track progress. Each goal should be concrete and verifiable.
+
+Example:
+- [ ] Implement RL-specific drivers in the worker crate.
+- [ ] Update the scheduler to handle experience aggregation and replay buffer coordination.
+- [ ] Ensure backward compatibility for standard DiLoCo training jobs.
+- [ ] Document the RL workflow in the onboarding guide.
+-->
+
+## Technical Approach
+
+<!--
+Describe the high-level architectural changes required. This helps reviewers and contributors understand the scope and complexity.
+
+Consider addressing:
+- Which crates or components will be modified (gateway, scheduler, worker, data)?
+- Are new protocols, traits, or APIs needed?
+- How does this interact with existing systems (libp2p networking, mTLS, resource allocation)?
+
+Example: "We will introduce a new `PolicyLearner` trait in the worker crate. The existing lease mechanism will be extended to track RL-specific resource requirements."
+-->
+
+## Dependencies
+
+<!--
+List any blockers, prerequisites, or related work. This helps with planning and prioritization.
+
+Examples:
+- Blocked by #80 (mTLS certificate rotation)
+- Requires RFC approval: `rfc/2025-xx-xx_rl_support.md`
+- Depends on upstream libp2p release for new transport feature
+- Related user stories: #42, #56
+
+Feel free to update this section as dependencies are discovered or resolved!
+-->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,55 @@
+---
+name: Task
+about: A specific, assignable unit of work (dev, docs, or ops)
+title: "Task: "
+labels: 'task'
+assignees: ''
+
+---
+
+## Description
+
+<!--
+Describe what specifically needs to be done. Be concrete and actionable.
+
+Example: "Update the `hypha-inspect` CLI to support looking up peers by their public key, enabling operators to diagnose certificate mismatches without needing to know the full PeerId."
+-->
+
+## Context
+
+<!--
+Help others understand where this task fits in the bigger picture.
+
+Examples:
+- Parent epic: #123
+- Related RFC: `rfc/2025-06-04_decentralized_task_announcement_protocol.md`
+- Spawned from discussion in #456
+
+Feel free to include any background that would help someone pick up this task!
+-->
+
+## Acceptance Criteria
+
+<!--
+Define what "done" looks like. Use checkboxes so progress can be tracked.
+
+Example:
+- [ ] CLI accepts `--pubkey` argument for secp256k1 keys.
+- [ ] Output matches the existing format of `cert-info`.
+- [ ] Unit tests covering the key conversion are passing.
+- [ ] `--help` text is updated with the new option.
+-->
+
+## Implementation Hints (Optional)
+
+<!--
+Share any pointers that would help someone get started quickly. This section is optional but appreciated!
+
+Examples:
+- Relevant code: `crates/inspect/src/main.rs`
+- Useful library: `libp2p::identity::Keypair::from_protobuf_encoding`
+- Similar pattern: See how `--peer-id` lookup works in the same file
+- Tip: The `hypha-crypto` crate has helpers for key format conversion
+
+Don't worry if you're not sure, implementers can always ask questions!
+-->

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,0 +1,44 @@
+---
+name: User Story
+about: Articulate a need from a user's perspective (Data Scientist, Operator, Developer)
+title: "User Story: "
+labels: 'user story'
+assignees: ''
+
+---
+
+## Description
+
+<!--
+Describe the user need using the standard format below. This structure helps us understand who benefits and why.
+-->
+
+As a **[Role: e.g., Data Scientist, Node Operator, Platform Developer]**,
+I want to **[Goal: e.g., monitor my training loss in real-time]**,
+So that **[Benefit: e.g., I can stop failed runs early and save compute credits]**.
+
+## Acceptance Criteria
+
+<!--
+Define what "done" looks like. Use checkboxes for each criterion so progress can be tracked.
+
+Example:
+- [ ] User can connect a TensorBoard instance to the worker node.
+- [ ] Metrics are flushed to the logging endpoint every 10 seconds.
+- [ ] The scheduler dashboard displays live loss curves for active jobs.
+- [ ] Documentation is updated with the new monitoring workflow.
+-->
+
+## Technical Considerations
+
+<!--
+Share any constraints, dependencies, or Hypha-specific details that may affect implementation. This context helps developers make informed decisions.
+
+Examples:
+- "Must work over the existing libp2p circuit relay to avoid opening new ports."
+- "Should respect mTLS requirements; metrics endpoints must be authenticated."
+- "Needs to integrate with the existing `hypha-inspect probe` tooling."
+- "Consider backward compatibility with workers running older versions."
+
+Feel free to include links to relevant docs, RFCs, or related issues!
+-->


### PR DESCRIPTION
Added tailored GitHub templates for bug reports, epics, tasks, and user stories so contributors capture the Hypha-specific context, examples, and security reminders we need for faster triage.