### PR TITLE
Hash-based data slice addressing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,22 +76,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -179,7 +179,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -191,7 +191,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -232,7 +232,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -283,9 +283,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -293,11 +293,10 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -306,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core",
  "bytes",
@@ -368,7 +367,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -404,29 +403,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.108",
-]
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bit-set"
@@ -496,7 +475,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -507,9 +486,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
@@ -547,23 +526,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -606,21 +576,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -637,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -656,7 +615,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -837,9 +796,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -869,7 +828,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -895,7 +854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -954,7 +913,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -997,7 +956,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1018,12 +977,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1149cf7462e5e79e17a3c05fd5b1f9055092bbfa95e04c319395c3beacc9370f"
 dependencies = [
  "convert_case",
- "itertools 0.14.0",
+ "itertools",
  "optfield",
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1124,7 +1083,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1192,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fnv"
@@ -1306,7 +1265,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1595,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1635,12 +1594,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1698,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1822,12 +1775,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1868,9 +1820,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1922,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -1990,8 +1942,10 @@ dependencies = [
  "libp2p",
  "libp2p-stream",
  "miette",
+ "rayon",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tokio-retry",
  "tracing",
@@ -2037,9 +1991,7 @@ dependencies = [
  "indoc",
  "libp2p",
  "miette",
- "reqwest",
  "serde",
- "serde_json",
  "tokio",
  "tracing",
  "tracing-indicatif",
@@ -2061,7 +2013,6 @@ dependencies = [
 name = "hypha-messages"
 version = "0.0.0"
 dependencies = [
- "hypha-network",
  "hypha-resources",
  "libp2p",
  "serde",
@@ -2120,7 +2071,7 @@ dependencies = [
  "hypha-resources",
  "hypha-telemetry",
  "indoc",
- "itertools 0.14.0",
+ "itertools",
  "libp2p",
  "libp2p-stream",
  "miette",
@@ -2367,12 +2318,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -2429,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
@@ -2448,15 +2399,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2485,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2501,9 +2443,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libloading"
@@ -2512,7 +2454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2907,7 +2849,7 @@ source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747
 dependencies = [
  "heck",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3022,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -3110,7 +3052,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3136,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -3168,7 +3110,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3466,7 +3408,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3614,7 +3556,7 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3664,7 +3606,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3693,7 +3635,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3751,7 +3693,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3780,7 +3722,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3876,22 +3818,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.108",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.7",
+ "toml_edit 0.23.9",
 ]
 
 [[package]]
@@ -3911,7 +3843,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "version_check",
  "yansi",
 ]
@@ -3936,7 +3868,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3975,10 +3907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4092,9 +4024,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -4338,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -4419,9 +4351,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4447,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4597,7 +4529,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4682,9 +4614,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -4782,7 +4714,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4825,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4851,7 +4783,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4974,7 +4906,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4985,7 +4917,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5077,7 +5009,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5115,9 +5047,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5189,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap",
  "toml_datetime 0.7.3",
@@ -5278,9 +5210,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -5308,9 +5240,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -5320,20 +5252,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5341,9 +5273,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-indicatif"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d4e11e0e27acef25a47f27e9435355fecdc488867fa2bc90e75b0700d2823d"
+checksum = "e1ef6990e0438749f0080573248e96631171a0b5ddfddde119aa5ba8c3a9c47e"
 dependencies = [
  "indicatif",
  "tracing",
@@ -5383,9 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5552,20 +5484,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.108",
+ "syn 2.0.111",
  "url",
  "uuid",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5647,9 +5579,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5660,9 +5592,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5673,9 +5605,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5683,22 +5615,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
@@ -5718,9 +5650,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5738,9 +5670,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5782,24 +5714,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -5814,20 +5740,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -5872,7 +5798,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5912,7 +5838,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -6063,9 +5989,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -6219,7 +6145,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -6231,28 +6157,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -6272,7 +6198,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -6312,7 +6238,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,14 @@ members = [
     "crates/config",
     "crates/data",
     "crates/gateway",
+    "crates/inspect",
     "crates/leases",
     "crates/messages",
     "crates/network",
-    "crates/scheduler",
-    "crates/worker",
-    "crates/telemetry",
     "crates/resources",
-    "crates/inspect",
+    "crates/scheduler",
+    "crates/telemetry",
+    "crates/worker",
 ]
 default-members = [
     "crates/certutil",
@@ -33,19 +33,19 @@ axum = { version = "0.8.4", features = ["http2"] }
 candle-core = "0.9.1"
 ciborium = "0.2.2"
 clap = { version = "4.5.31", features = ["derive"] }
+console = "0.15.8"
 documented = "0.9.2"
 figment = { version = "0.10", features = ["toml", "env"] }
-indoc = "2"
 futures-util = "0.3"
 http-body-util = "0.1.3"
-indicatif = "0.18.3"
-console = "0.15.8"
 hypha-config = { path = "crates/config" }
 hypha-leases = { path = "crates/leases" }
 hypha-messages = { path = "crates/messages" }
 hypha-network = { path = "crates/network" }
-hypha-telemetry = { path = "crates/telemetry" }
 hypha-resources = { path = "crates/resources" }
+hypha-telemetry = { path = "crates/telemetry" }
+indicatif = "0.18.3"
+indoc = "2"
 libp2p = { version = "0.56.0", features = [
     "cbor",
     "dcutr",
@@ -71,9 +71,11 @@ mockall = "0.13.1"
 nix = { version = "0.30.1", features = ["signal"] }
 pin-project = "1.1.7"
 proptest = "1.6.0"
+rayon = "1.11.0"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
-rustls = { version = "0.23", features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["stream", "json", "rustls-tls"] }
+rustls = { version = "0.23", features = ["std"] }
+rustls-pemfile = "2.1"
 safetensors = "0.4.5"
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.140"
@@ -95,8 +97,8 @@ tokio-util = { version = "0.7.15", features = ["compat", "rt"] }
 toml = { version = "0.9.5" }
 tower = { version = "0.5.2", features = ["util"] }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tracing-indicatif = "0.3.6"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 utoipa = { version = "5.4.0", features = ["axum_extras", "url", "uuid"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 

--- a/crates/certutil/Cargo.toml
+++ b/crates/certutil/Cargo.toml
@@ -19,6 +19,6 @@ thiserror.workspace = true
 time = "0.3.41"
 
 [build-dependencies]
-indoc.workspace = true
 clap.workspace = true
 clap-markdown = "0.1.5"
+indoc.workspace = true

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -19,17 +19,19 @@ indoc.workspace = true
 libp2p.workspace = true
 libp2p-stream.workspace = true
 miette.workspace = true
+rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tokio.workspace = true
 tokio-retry.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [build-dependencies]
-indoc.workspace = true
 clap.workspace = true
+clap-markdown = "0.1.5"
 hypha-network.workspace = true
+indoc.workspace = true
 libp2p.workspace = true
 serde.workspace = true
-clap-markdown = "0.1.5"

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, io, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use figment::{
@@ -7,7 +7,9 @@ use figment::{
 };
 use futures_util::{StreamExt, future::join_all};
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
-use hypha_data::{config::Config, network::Network, tensor_data::serialize_file};
+use hypha_data::{
+    config::Config, hash::get_file_sha256, network::Network, tensor_data::serialize_file,
+};
 use hypha_messages::{DataRecord, health};
 use hypha_network::{
     dial::DialInterface, kad::KademliaInterface, listen::ListenInterface,
@@ -17,6 +19,7 @@ use hypha_network::{
 use hypha_telemetry as telemetry;
 use libp2p::{Multiaddr, kad, multiaddr::Protocol};
 use miette::{IntoDiagnostic, Result};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tokio::{
     fs,
     signal::unix::{SignalKind, signal},
@@ -188,13 +191,28 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         return Err(miette::miette!("Dataset directory is empty"));
     }
 
+    let dataset_hashes = tokio::task::spawn_blocking(move || {
+        // Hash the dataset files
+        dataset_files
+            .par_iter()
+            .map(|file| {
+                let hash = get_file_sha256(file);
+                hash.map(|h| (h, file.clone()))
+            })
+            .collect::<Result<Vec<_>, io::Error>>()
+    })
+    .await
+    .into_diagnostic()?
+    .into_diagnostic()?;
+    let dataset_hashes: HashMap<String, PathBuf> = HashMap::from_iter(dataset_hashes);
+
     // Announce our dataset
     tracing::info!(dataset_name, "Announcing");
     let _ = network
         .store(kad::Record::new(
             kad::RecordKey::new(&dataset_name),
             serde_json::to_vec(&DataRecord {
-                num_slices: dataset_files.len() as u64,
+                slice_hashes: dataset_hashes.keys().cloned().collect(),
             })
             .map_err(|err| miette::miette!("Failed to serialize dataset record: {}", err))?,
         ))
@@ -202,20 +220,21 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
 
     let stream_pulls = network.streams_pull().expect("an unregistered pull stream").for_each_concurrent(None, {
         |(peer_id, resource, mut stream)| {
-            let dataset_files = dataset_files.clone();
+            let dataset_hashes = dataset_hashes.clone();
             async move {
-                tracing::info!(peer_id = %peer_id, dataset = resource.dataset, slice= resource.index, "Sending tensor to peer");
+                tracing::info!(peer_id = %peer_id, dataset = resource.dataset, slice = resource.hash, "Sending tensor to peer");
 
                 if dataset_name == resource.dataset.as_str() {
-                    // Use the provided offsets to select a subset of the available dataset files.
-                    if resource.index as usize > dataset_files.len() {
-                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Invalid index for dataset");
-                        return;
-                    }
-                    let dataset_slice = &dataset_files[resource.index as usize];
-
-                    if let Err(e) = serialize_file(dataset_slice, &mut stream).await {
-                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to serialize dataset: {}", e);
+                    // Use the provided hash to select a subset of the available dataset files.
+                    match dataset_hashes.get(&resource.hash) {
+                        None => {
+                            tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Invalid hash for dataset");
+                        }
+                        Some(dataset_slice) => {
+                            if let Err(e) = serialize_file(dataset_slice, &mut stream).await {
+                                tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to serialize dataset: {}", e);
+                            }
+                        },
                     }
                 } else {
                     tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "No dataset found with that name");

--- a/crates/data/src/hash.rs
+++ b/crates/data/src/hash.rs
@@ -1,0 +1,15 @@
+use std::{fs::File, io, path::Path};
+
+use sha2::{Digest, Sha256};
+
+pub fn get_file_sha256<P>(path: P) -> io::Result<String>
+where
+    P: AsRef<Path>,
+{
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+
+    let _n = io::copy(&mut file, &mut hasher)?;
+    let hash = hasher.finalize();
+    Ok(format!("sha256:{:x}", hash))
+}

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
+pub mod hash;
 pub mod network;
 pub mod tensor_data;

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -12,8 +12,8 @@ documented.workspace = true
 figment.workspace = true
 futures-util.workspace = true
 hypha-config.workspace = true
-hypha-network.workspace = true
 hypha-messages.workspace = true
+hypha-network.workspace = true
 hypha-telemetry.workspace = true
 indoc.workspace = true
 libp2p.workspace = true
@@ -25,8 +25,8 @@ tracing-subscriber.workspace = true
 
 [build-dependencies]
 clap.workspace = true
+clap-markdown = "0.1.5"
 hypha-network.workspace = true
 indoc.workspace = true
 libp2p.workspace = true
 serde.workspace = true
-clap-markdown = "0.1.5"

--- a/crates/inspect/Cargo.toml
+++ b/crates/inspect/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 clap.workspace = true
+console.workspace = true
 documented.workspace = true
 figment.workspace = true
 futures-util.workspace = true
@@ -17,14 +18,11 @@ indicatif.workspace = true
 indoc.workspace = true
 libp2p.workspace = true
 miette.workspace = true
-reqwest.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-indicatif.workspace = true
 tracing-subscriber.workspace = true
-console.workspace = true
 x509-parser = "0.16"
 
 [build-dependencies]

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -6,8 +6,7 @@ edition.workspace = true
 license = "Apache-2.0"
 
 [dependencies]
+hypha-resources.workspace = true
 libp2p.workspace = true
 serde.workspace = true
 uuid.workspace = true
-hypha-network.workspace = true
-hypha-resources.workspace = true

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -803,7 +803,7 @@ pub mod data {
     /// Data server responds with data or error
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub enum Response {
-        Success { data_provider: PeerId, index: u64 },
+        Success { data_provider: PeerId, hash: String },
         NotFound,
         Error(String),
     }
@@ -818,11 +818,11 @@ pub struct ParameterStreamHeader {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataRecord {
-    pub num_slices: u64,
+    pub slice_hashes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataSlice {
     pub dataset: String,
-    pub index: u64,
+    pub hash: String,
 }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 ed25519-dalek = { version = "2.1", features = ["alloc", "pkcs8", "pem"] }
 futures-util.workspace = true
+ipnet = { version = "2", features = ["serde"] }
 libp2p.workspace = true
 libp2p-stream.workspace = true
 pin-project.workspace = true
@@ -20,7 +21,6 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-ipnet = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 clap.workspace = true

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -38,12 +38,12 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-indoc.workspace = true
 clap.workspace = true
+clap-markdown = "0.1.5"
 hypha-network.workspace = true
+indoc.workspace = true
 libp2p.workspace = true
 serde.workspace = true
-clap-markdown = "0.1.5"
 
 [dev-dependencies]
 tokio = { version = "1.43.0", features = [

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -249,7 +249,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         network.clone(),
         data_provider,
         dataset.clone(),
-        dataset_record.num_slices,
+        dataset_record.slice_hashes,
     );
 
     let tracker_task = tokio::spawn(

--- a/crates/scheduler/src/scheduling/data_scheduler.rs
+++ b/crates/scheduler/src/scheduling/data_scheduler.rs
@@ -43,13 +43,13 @@ where
         network: TBehaviour,
         data_provider: PeerId,
         dataset: String,
-        num_slices: u64,
+        slice_hashes: Vec<String>,
     ) -> Self {
         Self {
             network,
             data_provider,
             dataset,
-            slice_tracker: Arc::new(Mutex::new(SliceTracker::new(num_slices))),
+            slice_tracker: Arc::new(Mutex::new(SliceTracker::new(slice_hashes))),
         }
     }
 
@@ -78,11 +78,11 @@ where
                     async move {
                         let peer_id = request.0;
                         tracing::debug!(%peer_id, "Received data slice request");
-                        let index = tracker.lock().await.next(&peer_id);
-                        tracing::debug!(%peer_id, "Picked data slice {}", index);
+                        let hash = tracker.lock().await.next(&peer_id);
+                        tracing::debug!(%peer_id, "Picked data slice {}", hash);
                         api::Response::Data(data::Response::Success {
                             data_provider,
-                            index,
+                            hash,
                         })
                     }
                 })

--- a/crates/scheduler/src/tracker/slice.rs
+++ b/crates/scheduler/src/tracker/slice.rs
@@ -14,17 +14,17 @@ pub enum SliceError {
     Scheduling(String),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Slice {
-    id: u64,
+    hash: String,
     peer: Option<PeerId>,
     processed: bool,
 }
 
 impl Slice {
-    pub fn new(id: u64) -> Self {
+    pub fn new(hash: String) -> Self {
         Slice {
-            id,
+            hash,
             peer: None,
             processed: false,
         }
@@ -34,20 +34,20 @@ impl Slice {
 /// This tracks the data slices provided by a data node.
 pub struct SliceTracker {
     slices: Vec<Slice>,
-    processing: HashMap<PeerId, u64>,
+    processing: HashMap<PeerId, String>,
     rounds: u32,
 }
 
 impl SliceTracker {
-    pub fn new(num_slices: u64) -> Self {
+    pub fn new(slice_hashes: Vec<String>) -> Self {
         Self {
-            slices: Vec::from_iter((0..num_slices).map(Slice::new)),
+            slices: slice_hashes.into_iter().map(Slice::new).collect(),
             processing: HashMap::new(),
             rounds: 0,
         }
     }
 
-    pub fn next(&mut self, peer: &PeerId) -> u64 {
+    pub fn next(&mut self, peer: &PeerId) -> String {
         let open_slice = self
             .slices
             .iter_mut()
@@ -58,8 +58,8 @@ impl SliceTracker {
             Some(slice) => {
                 slice.processed = true;
                 slice.peer = Some(*peer);
-                self.processing.insert(*peer, slice.id);
-                slice.id
+                self.processing.insert(*peer, slice.hash.clone());
+                slice.hash.clone()
             }
             None => {
                 // We use a cache stealing strategy. If a worker is slower, other workers can steal their cached data.
@@ -85,8 +85,8 @@ impl SliceTracker {
                             .expect("Slice");
                         slice.processed = true;
                         slice.peer = Some(*peer);
-                        self.processing.insert(*peer, slice.id);
-                        slice.id
+                        self.processing.insert(*peer, slice.hash.clone());
+                        slice.hash.clone()
                     }
                     None => {
                         tracing::info!("All slices have been processed. Start new round");
@@ -106,8 +106,8 @@ impl SliceTracker {
         while let Some(s) = self.slices.iter_mut().find(|s| s.peer == Some(*peer)) {
             s.peer = None;
         }
-        if let Some(s_id) = self.processing.remove(peer)
-            && let Some(slice) = self.slices.iter_mut().find(|s| s.id == s_id)
+        if let Some(s_hash) = self.processing.remove(peer)
+            && let Some(slice) = self.slices.iter_mut().find(|s| s.hash == s_hash)
         {
             slice.processed = false;
         }
@@ -124,51 +124,67 @@ mod batch_scheduler_tests {
     async fn simple_scheduling() {
         let peer_1 = PeerId::random();
         let peer_2 = PeerId::random();
-        let num_slices = 7;
+        let slice_hashes = vec![
+            "0".to_string(),
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string(),
+            "6".to_string(),
+        ];
 
-        let mut tracker = SliceTracker::new(num_slices);
+        let mut tracker = SliceTracker::new(slice_hashes);
 
-        assert_eq!(tracker.next(&peer_1), 0);
-        assert_eq!(tracker.next(&peer_2), 1);
-        assert_eq!(tracker.next(&peer_1), 2);
-        assert_eq!(tracker.next(&peer_2), 3);
-        assert_eq!(tracker.next(&peer_1), 4);
-        assert_eq!(tracker.next(&peer_2), 5);
-        assert_eq!(tracker.next(&peer_1), 6);
-        assert_eq!(tracker.next(&peer_2), 1);
-        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_1), "0".to_string());
+        assert_eq!(tracker.next(&peer_2), "1".to_string());
+        assert_eq!(tracker.next(&peer_1), "2".to_string());
+        assert_eq!(tracker.next(&peer_2), "3".to_string());
+        assert_eq!(tracker.next(&peer_1), "4".to_string());
+        assert_eq!(tracker.next(&peer_2), "5".to_string());
+        assert_eq!(tracker.next(&peer_1), "6".to_string());
+        assert_eq!(tracker.next(&peer_2), "1".to_string());
+        assert_eq!(tracker.next(&peer_1), "0".to_string());
     }
 
     #[tokio::test]
     async fn fast_slow_scheduling() {
         let peer_1 = PeerId::random();
         let peer_2 = PeerId::random();
-        let num_slices = 7;
+        let slice_hashes = vec![
+            "0".to_string(),
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string(),
+            "6".to_string(),
+        ];
 
-        let mut tracker = SliceTracker::new(num_slices);
+        let mut tracker = SliceTracker::new(slice_hashes);
 
         // Round 0
-        assert_eq!(tracker.next(&peer_1), 0);
-        assert_eq!(tracker.next(&peer_1), 1);
-        assert_eq!(tracker.next(&peer_1), 2);
-        assert_eq!(tracker.next(&peer_2), 3);
-        assert_eq!(tracker.next(&peer_1), 4);
-        assert_eq!(tracker.next(&peer_1), 5);
-        assert_eq!(tracker.next(&peer_1), 6);
+        assert_eq!(tracker.next(&peer_1), "0".to_string());
+        assert_eq!(tracker.next(&peer_1), "1".to_string());
+        assert_eq!(tracker.next(&peer_1), "2".to_string());
+        assert_eq!(tracker.next(&peer_2), "3".to_string());
+        assert_eq!(tracker.next(&peer_1), "4".to_string());
+        assert_eq!(tracker.next(&peer_1), "5".to_string());
+        assert_eq!(tracker.next(&peer_1), "6".to_string());
         // Round 1
-        assert_eq!(tracker.next(&peer_2), 3);
-        assert_eq!(tracker.next(&peer_1), 0);
-        assert_eq!(tracker.next(&peer_1), 1);
-        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), "3".to_string());
+        assert_eq!(tracker.next(&peer_1), "0".to_string());
+        assert_eq!(tracker.next(&peer_1), "1".to_string());
+        assert_eq!(tracker.next(&peer_1), "2".to_string());
         let slice = tracker.next(&peer_2);
-        let mut left_slices = vec![4, 5, 6];
+        let mut left_slices = vec!["4".to_string(), "5".to_string(), "6".to_string()];
         assert!(left_slices.contains(&slice));
         left_slices.retain(|f| f != &slice);
         assert!(left_slices.contains(&tracker.next(&peer_1)));
         assert!(left_slices.contains(&tracker.next(&peer_1)));
         // Round 2
-        assert_eq!(tracker.next(&peer_1), 0);
-        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), "0".to_string());
+        assert_eq!(tracker.next(&peer_2), "3".to_string());
         assert_eq!(tracker.rounds, 2);
     }
 
@@ -177,27 +193,35 @@ mod batch_scheduler_tests {
         let peer_1 = PeerId::random();
         let peer_2 = PeerId::random();
         let peer_3 = PeerId::random();
-        let num_slices = 7;
+        let slice_hashes = vec![
+            "0".to_string(),
+            "1".to_string(),
+            "2".to_string(),
+            "3".to_string(),
+            "4".to_string(),
+            "5".to_string(),
+            "6".to_string(),
+        ];
 
-        let mut tracker = SliceTracker::new(num_slices);
+        let mut tracker = SliceTracker::new(slice_hashes);
 
         // Round 0
-        assert_eq!(tracker.next(&peer_1), 0);
-        assert_eq!(tracker.next(&peer_2), 1);
-        assert_eq!(tracker.next(&peer_1), 2);
-        assert_eq!(tracker.next(&peer_2), 3);
-        assert_eq!(tracker.next(&peer_1), 4);
-        assert_eq!(tracker.next(&peer_2), 5);
-        assert_eq!(tracker.next(&peer_1), 6);
+        assert_eq!(tracker.next(&peer_1), "0".to_string());
+        assert_eq!(tracker.next(&peer_2), "1".to_string());
+        assert_eq!(tracker.next(&peer_1), "2".to_string());
+        assert_eq!(tracker.next(&peer_2), "3".to_string());
+        assert_eq!(tracker.next(&peer_1), "4".to_string());
+        assert_eq!(tracker.next(&peer_2), "5".to_string());
+        assert_eq!(tracker.next(&peer_1), "6".to_string());
         tracker.remove_worker(&peer_1);
-        assert_eq!(tracker.next(&peer_3), 6);
+        assert_eq!(tracker.next(&peer_3), "6".to_string());
         // Round 1
-        assert_eq!(tracker.next(&peer_2), 0);
-        assert_eq!(tracker.next(&peer_3), 2);
-        assert_eq!(tracker.next(&peer_2), 1);
-        assert_eq!(tracker.next(&peer_3), 4);
-        assert_eq!(tracker.next(&peer_2), 3);
-        assert_eq!(tracker.next(&peer_3), 6);
-        assert_eq!(tracker.next(&peer_2), 5);
+        assert_eq!(tracker.next(&peer_2), "0".to_string());
+        assert_eq!(tracker.next(&peer_3), "2".to_string());
+        assert_eq!(tracker.next(&peer_2), "1".to_string());
+        assert_eq!(tracker.next(&peer_3), "4".to_string());
+        assert_eq!(tracker.next(&peer_2), "3".to_string());
+        assert_eq!(tracker.next(&peer_3), "6".to_string());
+        assert_eq!(tracker.next(&peer_2), "5".to_string());
     }
 }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -6,28 +6,27 @@ edition.workspace = true
 license = "Apache-2.0"
 description = "Hypha telemetry utilities with OTLP metrics and libp2p bandwidth instrumentation"
 
+[features]
+default = []
+
 [dependencies]
-futures-util = "0.3"
 futures-io = "0.3"
+futures-util = "0.3"
+http = "1.1"
 libp2p = { workspace = true }
 opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["metrics", "logs", "rt-tokio", "testing"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-proto", "reqwest-blocking-client", "reqwest-rustls", "logs" ] }
 opentelemetry-appender-tracing = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-proto", "reqwest-blocking-client", "reqwest-rustls", "logs" ] }
+opentelemetry_sdk = { version = "0.31", features = ["metrics", "logs", "rt-tokio", "testing"] }
 pin-project = { workspace = true }
 serde.workspace = true
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-http = "1.1"
-
-
-[features]
-default = []
 
 [dev-dependencies]
-serde_json = "1.0"
-proptest.workspace = true
 futures-executor = "0.3"
 futures-task = "0.3"
+proptest.workspace = true
+serde_json = "1.0"

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -45,12 +45,12 @@ utoipa.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-indoc.workspace = true
 clap.workspace = true
+clap-markdown = "0.1.5"
 hypha-network.workspace = true
+indoc.workspace = true
 libp2p.workspace = true
 serde.workspace = true
-clap-markdown = "0.1.5"
 
 [dev-dependencies]
 http-body-util.workspace = true

--- a/crates/worker/src/connector/mod.rs
+++ b/crates/worker/src/connector/mod.rs
@@ -474,23 +474,23 @@ where
                     {
                         Ok(api::Response::Data(data::Response::Success {
                             data_provider,
-                            index,
+                            hash,
                         })) => {
-                            tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, index, "Received slice index and data provider");
+                            tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, hash, "Received slice hash and data provider");
                             let stream = self
                                 .network
                                 .stream_pull(
                                     data_provider,
                                     &DataSlice {
                                         dataset: dataset.clone(),
-                                        index,
+                                        hash: hash.clone(),
                                     },
                                 )
                                 .await?;
                             let item = ReadItem {
                                 meta: ItemMeta {
                                     kind: "peer",
-                                    name: index.to_string(),
+                                    name: hash,
                                 },
                                 reader: Box::pin(stream),
                             };


### PR DESCRIPTION
Uses hashes instead of indices to address the individual slices of a dataset. This will make it easier for workers to keep track of slices they already know and implement caching. When starting a data node, it'll compute hashes of all files of a dataset and announce these in the DHT.