### PR TITLE
Simple data slice caching

### DIFF
--- a/crates/worker/src/connector/mod.rs
+++ b/crates/worker/src/connector/mod.rs
@@ -5,7 +5,7 @@ use std::{io, pin::Pin, sync::Arc};
 use futures_util::{Stream, StreamExt, TryStreamExt};
 use hf_hub::api::tokio::ApiBuilder;
 use hypha_messages::{
-    DataSlice, Fetch, Receive, Reference, SelectionStrategy, Send as SendRef, api, data,
+    DataSlice, Fetch, Receive, Reference, SelectionStrategy, Send as SendRef, api,
 };
 use hypha_network::{
     request_response::RequestResponseInterface,
@@ -128,9 +128,6 @@ where
         };
         // Register built-ins
         this.fetchers.push(Arc::new(HttpHfFetcher));
-        this.fetchers.push(Arc::new(PeerStreamPullConnector {
-            network: network.clone(),
-        }));
         let peer = PeerStreamPushConnector {
             network: network.clone(),
         };
@@ -427,80 +424,6 @@ where
                     Ok(Box::pin(stream) as ReadItemStream)
                 }
                 _ => Err(ConnectorError::UnsupportedReceive(recv.as_ref().clone())),
-            }
-        })
-    }
-}
-
-#[derive(Clone)]
-struct PeerStreamPullConnector<T>
-where
-    T: Clone + StreamPullInterface + StreamPullSenderInterface<DataSlice> + Send + Sync + 'static,
-{
-    network: T,
-}
-
-impl<T> FetchConnector for PeerStreamPullConnector<T>
-where
-    T: Clone
-        + RequestResponseInterface<api::Codec>
-        + StreamPullInterface
-        + StreamPullSenderInterface<DataSlice>
-        + Send
-        + Sync
-        + 'static,
-{
-    fn supports(&self, r: &Reference) -> bool {
-        matches!(r, Reference::Scheduler { .. })
-    }
-
-    fn fetch<'a>(
-        &'a self,
-        fetch: &'a Fetch,
-    ) -> Pin<Box<dyn Future<Output = Result<ReadItemStream, ConnectorError>> + Send + 'a>> {
-        Box::pin(async move {
-            match fetch.as_ref() {
-                Reference::Scheduler { peer, dataset } => {
-                    tracing::debug!(peer_id = %peer, dataset, "Requesting data slice index from scheduler");
-                    match self
-                        .network
-                        .request(
-                            *peer,
-                            api::Request::Data(data::Request {
-                                dataset: dataset.clone(),
-                            }),
-                        )
-                        .await
-                    {
-                        Ok(api::Response::Data(data::Response::Success {
-                            data_provider,
-                            hash,
-                        })) => {
-                            tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, hash, "Received slice hash and data provider");
-                            let stream = self
-                                .network
-                                .stream_pull(
-                                    data_provider,
-                                    &DataSlice {
-                                        dataset: dataset.clone(),
-                                        hash: hash.clone(),
-                                    },
-                                )
-                                .await?;
-                            let item = ReadItem {
-                                meta: ItemMeta {
-                                    kind: "peer",
-                                    name: hash,
-                                },
-                                reader: Box::pin(stream),
-                            };
-                            let s = futures_util::stream::once(async move { Ok(item) });
-                            Ok(Box::pin(s) as ReadItemStream)
-                        }
-                        _ => Err(ConnectorError::UnsupportedFetch(fetch.as_ref().clone())),
-                    }
-                }
-                _ => Err(ConnectorError::UnsupportedFetch(fetch.as_ref().clone())),
             }
         })
     }

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -18,10 +18,14 @@ use axum::{
 };
 use futures_util::{StreamExt, stream};
 use hypha_messages::{
-    Fetch, Receive, Reference, Send,
+    DataSlice, Fetch, Receive, Reference, Send,
     action::{self, ActionRequest},
+    api, data,
 };
-use hypha_network::request_response::RequestResponseError;
+use hypha_network::{
+    request_response::{RequestResponseError, RequestResponseInterface},
+    stream_pull::StreamPullSenderInterface,
+};
 use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -220,39 +224,110 @@ async fn fetch_resource(
     let retry_strategy = ExponentialBackoff::from_millis(100).map(jitter).take(3);
     validate_fetch(&resource)?;
 
-    let out = Retry::spawn(retry_strategy, || {
-        let state = state.clone();
-        let resource = resource.clone();
-        let dir_rel = "artifacts".to_string();
-        let mut out: Vec<FileResponse> = Vec::new();
-        async move {
-            let dir_abs = safe_join(&state.work_dir, &dir_rel)?;
-            fs::create_dir_all(&dir_abs).await?;
-            let mut items = state.connector.fetch(resource).await?;
-            let mut idx: usize = 0;
-            while let Some(item) = items.next().await.transpose().map_err(Error::Io)? {
-                let (file_name, mut reader) = derive_name_and_reader(item, idx);
-                let rel = format!("{}/{}", dir_rel, file_name);
-                let abs = safe_join(&state.work_dir, &rel)?;
-                if let Some(parent) = abs.parent() {
-                    fs::create_dir_all(parent).await?;
+    match resource.as_ref() {
+        // Resolve scheduler fetches:
+        // We request a data slice from the scheduler
+        Reference::Scheduler { peer, dataset } => {
+            tracing::debug!(peer_id = %peer, dataset, "Requesting data slice index from scheduler");
+            match <Network as RequestResponseInterface<api::Codec>>::request(
+                &state.network,
+                *peer,
+                api::Request::Data(data::Request {
+                    dataset: dataset.clone(),
+                }),
+            )
+            .await
+            {
+                Ok(api::Response::Data(data::Response::Success {
+                    data_provider,
+                    hash,
+                })) => {
+                    tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, hash, "Received slice index and data provider");
+
+                    let out = Retry::spawn(retry_strategy, || {
+                        let hash = hash.clone();
+                        let state = state.clone();
+                        let dir_rel = "artifacts".to_string();
+                        let mut out: Vec<FileResponse> = Vec::new();
+                        async move {
+                            let dir_abs = safe_join(&state.work_dir, &dir_rel)?;
+                            fs::create_dir_all(&dir_abs).await?;
+
+                            let file_name = hash.clone();
+                            let mut reader = state
+                                .network
+                                .stream_pull(
+                                    data_provider,
+                                    &DataSlice {
+                                        dataset: dataset.clone(),
+                                        hash: hash.clone(),
+                                    },
+                                )
+                                .await
+                                .unwrap();
+
+                            let rel = format!("{}/{}", dir_rel, file_name);
+                            let abs = safe_join(&state.work_dir, &rel)?;
+                            if let Some(parent) = abs.parent() {
+                                fs::create_dir_all(parent).await?;
+                            }
+
+                            let mut file = fs::File::create(&abs).await?;
+                            let size = tokio::io::copy(&mut reader, &mut file).await?;
+                            file.sync_all().await?;
+                            tracing::info!(size, file = %abs.display(), "Copied resource");
+                            set_permissions(&abs, Permissions::from_mode(0o600)).await?;
+
+                            out.push(FileResponse { path: rel, size });
+
+                            Ok::<std::vec::Vec<FileResponse>, Error>(out)
+                        }
+                    })
+                    .await?;
+
+                    Ok(Json(out))
                 }
-
-                let mut file = fs::File::create(&abs).await?;
-                let size = tokio::io::copy(&mut reader, &mut file).await?;
-                file.sync_all().await?;
-                tracing::info!(size, file = %abs.display(), "Copied resource");
-                set_permissions(&abs, Permissions::from_mode(0o600)).await?;
-
-                out.push(FileResponse { path: rel, size });
-                idx += 1;
+                _ => Err(Error::Connector(ConnectorError::UnsupportedFetch(
+                    resource.as_ref().clone(),
+                ))),
             }
-            Ok::<std::vec::Vec<FileResponse>, Error>(out)
         }
-    })
-    .await?;
+        _ => {
+            let out = Retry::spawn(retry_strategy, || {
+                let state = state.clone();
+                let resource = resource.clone();
+                let dir_rel = "artifacts".to_string();
+                let mut out: Vec<FileResponse> = Vec::new();
+                async move {
+                    let dir_abs = safe_join(&state.work_dir, &dir_rel)?;
+                    fs::create_dir_all(&dir_abs).await?;
+                    let mut items = state.connector.fetch(resource).await?;
+                    let mut idx: usize = 0;
+                    while let Some(item) = items.next().await.transpose().map_err(Error::Io)? {
+                        let (file_name, mut reader) = derive_name_and_reader(item, idx);
+                        let rel = format!("{}/{}", dir_rel, file_name);
+                        let abs = safe_join(&state.work_dir, &rel)?;
+                        if let Some(parent) = abs.parent() {
+                            fs::create_dir_all(parent).await?;
+                        }
 
-    Ok(Json(out))
+                        let mut file = fs::File::create(&abs).await?;
+                        let size = tokio::io::copy(&mut reader, &mut file).await?;
+                        file.sync_all().await?;
+                        tracing::info!(size, file = %abs.display(), "Copied resource");
+                        set_permissions(&abs, Permissions::from_mode(0o600)).await?;
+
+                        out.push(FileResponse { path: rel, size });
+                        idx += 1;
+                    }
+                    Ok::<std::vec::Vec<FileResponse>, Error>(out)
+                }
+            })
+            .await?;
+
+            Ok(Json(out))
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::Permissions,
-    os::unix::fs::PermissionsExt,
+    os::unix::fs::{MetadataExt, PermissionsExt},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -226,7 +226,9 @@ async fn fetch_resource(
 
     match resource.as_ref() {
         // Resolve scheduler fetches:
-        // We request a data slice from the scheduler
+        // We request a data slice from the scheduler.
+        // If we already downloaded that slice, we use the existing one,
+        // otherwise we download it from a data provider.
         Reference::Scheduler { peer, dataset } => {
             tracing::debug!(peer_id = %peer, dataset, "Requesting data slice index from scheduler");
             match <Network as RequestResponseInterface<api::Codec>>::request(
@@ -254,31 +256,54 @@ async fn fetch_resource(
                             fs::create_dir_all(&dir_abs).await?;
 
                             let file_name = hash.clone();
-                            let mut reader = state
-                                .network
-                                .stream_pull(
-                                    data_provider,
-                                    &DataSlice {
-                                        dataset: dataset.clone(),
-                                        hash: hash.clone(),
-                                    },
-                                )
-                                .await
-                                .unwrap();
-
                             let rel = format!("{}/{}", dir_rel, file_name);
                             let abs = safe_join(&state.work_dir, &rel)?;
-                            if let Some(parent) = abs.parent() {
-                                fs::create_dir_all(parent).await?;
-                            }
 
-                            let mut file = fs::File::create(&abs).await?;
-                            let size = tokio::io::copy(&mut reader, &mut file).await?;
-                            file.sync_all().await?;
-                            tracing::info!(size, file = %abs.display(), "Copied resource");
-                            set_permissions(&abs, Permissions::from_mode(0o600)).await?;
+                            match fs::try_exists(&abs).await {
+                                // Cache hit!
+                                Ok(true) => {
+                                    tracing::debug!(
+                                        peer_id = %peer, data_peer_id = %data_provider,
+                                        dataset,
+                                        hash,
+                                        "File already exists, skipping data slice download"
+                                    );
 
-                            out.push(FileResponse { path: rel, size });
+                                    let metadata = fs::metadata(&abs).await?;
+
+                                    out.push(FileResponse {
+                                        path: rel,
+                                        size: metadata.size(),
+                                    });
+                                }
+                                // Cache miss!
+                                _ => {
+                                    tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, hash, "Downloading data slice");
+
+                                    let mut reader = state
+                                        .network
+                                        .stream_pull(
+                                            data_provider,
+                                            &DataSlice {
+                                                dataset: dataset.clone(),
+                                                hash: hash.clone(),
+                                            },
+                                        )
+                                        .await.map_err(|e| Error::Connector(ConnectorError::OpenStream(e)))?;
+
+                                    if let Some(parent) = abs.parent() {
+                                        fs::create_dir_all(parent).await?;
+                                    }
+
+                                    let mut file = fs::File::create(&abs).await?;
+                                    let size = tokio::io::copy(&mut reader, &mut file).await?;
+                                    file.sync_all().await?;
+                                    tracing::info!(size, file = %abs.display(), "Copied resource");
+                                    set_permissions(&abs, Permissions::from_mode(0o600)).await?;
+
+                                    out.push(FileResponse { path: rel, size });
+                                }
+                            };
 
                             Ok::<std::vec::Vec<FileResponse>, Error>(out)
                         }


### PR DESCRIPTION
Cache data slices in the simplest way possible: We store data slices in files. If we already have a file for a slice, which is uniquely identifiable by its hash, we don't download that slice again. For the moment, this works fine, because we only clean up created files when stopping a worker.

Let's merge #195 first, as this PR depends on it.