### PR TITLE
Remove ephemeral files after use

### DIFF
--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -392,6 +392,10 @@ async fn send_resource(
                         if cancel.is_cancelled() {
                             tracing::debug!(file = %file_path.display(), "send_resource: task cancelled");
                         }
+
+                        // We no longer need the file once it has been sent, so remove it.
+                        fs::remove_file(&file_path).await?;
+
                         break Ok::<(), Error>(());
                     };
                     let item = item_result?;

--- a/executors/accelerate/src/hypha/accelerate_executor/training.py
+++ b/executors/accelerate/src/hypha/accelerate_executor/training.py
@@ -226,6 +226,10 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
                                 path = os.path.join(work_dir, rel_path)
                                 model.load_state_dict(merge_models(previous_model_path, path))
                                 save_model(model, previous_model_path)
+
+                                # Once we updated the model, we no longer need the parameter file.
+                                os.remove(path)
+
                                 model = accelerator.prepare(model)
                 except StopIteration:
                     current_status = {


### PR DESCRIPTION
Hypha uses files to exchange large amount of data between workers and their executors. Some of these files are only needed for a short amount of time. For these cases, the files are now deleted, which results in fewer disc space consumed.