### PR TITLE
fix: scheduler shutdown

### DIFF
--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -393,32 +393,28 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         }))
     };
 
-    let (metrics_rx, batch_scheduler_handle) = BatchScheduler::run::<RunningMean, BasicSimulation>(
-        network.clone(),
-        worker_handle.clone(),
-        parameter_handle.clone(),
-        job_id,
-        diloco_config.resources.worker_pool.min as usize,
-        Duration::from_millis(diloco_config.resources.worker_pool.grace_ms),
-        diloco_config.rounds.avg_samples_between_updates,
-        diloco_config.rounds.update_rounds,
-        diloco_config.model_destination.clone(),
-        batch_sizer.clone(),
-    )
-    .await
-    .into_diagnostic()?;
+    let (metrics_rx, mut batch_scheduler_handle) =
+        BatchScheduler::run::<RunningMean, BasicSimulation>(
+            network.clone(),
+            worker_handle.clone(),
+            parameter_handle.clone(),
+            job_id,
+            diloco_config.resources.worker_pool.min as usize,
+            Duration::from_millis(diloco_config.resources.worker_pool.grace_ms),
+            diloco_config.rounds.avg_samples_between_updates,
+            diloco_config.rounds.update_rounds,
+            diloco_config.model_destination.clone(),
+            batch_sizer.clone(),
+        )
+        .await
+        .into_diagnostic()?;
 
     metrics_bridge.register_stream(ReceiverStream::new(metrics_rx));
 
     let cancel_token = token.clone();
-    let status_handle = tokio::spawn(async move {
-        tokio::select! {
-            Err(e) = metrics_bridge.run(cancel_token) => {
-                tracing::error!(error = %e, "Status bridge failed");
-            }
-            _ = batch_scheduler_handle => {
-                tracing::info!("Batch Scheduler finished");
-            }
+    let mut status_handle = tokio::spawn(async move {
+        if let Err(e) = metrics_bridge.run(cancel_token).await {
+            tracing::error!(error = %e, "Status bridge failed");
         }
     });
 
@@ -430,36 +426,55 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         _ = &mut driver_task => {
             tracing::warn!("Network driver terminated, shutting down");
         }
-        _ = status_handle => {
-            tracing::debug!("Scheduler terminated")
+        _ = &mut status_handle => {
+            tracing::error!("Status bridge terminated, shutting down");
+        }
+        _ = &mut batch_scheduler_handle => {
+            tracing::info!("Batch scheduler finished, shutting down");
         }
     }
 
     // NOTE: Graceful shutdown sequence:
     //
-    // 1. Stop network interfaces and ensure the driver is completed before telemetry shutdown.
+    // 1. Stop components
+    // 2. Stop network interfaces and ensure the driver is completed
+    // 3. Flush any remaining telemetry and shutdown providers
+    //
+    // IMPORTANT: Do not log anything after shutting down the telemetry providers
+
+    if !batch_scheduler_handle.is_finished() {
+        batch_scheduler_handle.abort();
+    }
+    let _ = batch_scheduler_handle.await;
+
+    if !parameter_dispatcher.is_finished() {
+        parameter_dispatcher.abort();
+    }
+    let _ = parameter_dispatcher.await;
+
+    if !worker_dispatcher.is_finished() {
+        worker_dispatcher.abort();
+    }
+    let _ = worker_dispatcher.await;
+
+    if !status_handle.is_finished() {
+        status_handle.abort();
+    }
+    let _ = status_handle.await;
+
+    if !tracker_task.is_finished() {
+        tracker_task.abort();
+    }
+    let _ = tracker_task.await;
     drop(network);
     if !driver_task.is_finished() {
         driver_task.abort();
     }
     let _ = driver_task.await;
-    if !parameter_dispatcher.is_finished() {
-        parameter_dispatcher.abort();
-    }
-    let _ = parameter_dispatcher.await;
-    if !worker_dispatcher.is_finished() {
-        worker_dispatcher.abort();
-    }
-    let _ = worker_dispatcher.await;
-    if !tracker_task.is_finished() {
-        tracker_task.abort();
-    }
-    let _ = tracker_task.await;
-    // 2. Flush any remaining telemetry and shutdown providers, do not log anything after this point
+
     metrics.shutdown().into_diagnostic()?;
     tracing.shutdown().into_diagnostic()?;
     logging.shutdown().into_diagnostic()?;
-
     Ok(())
 }
 

--- a/crates/scheduler/src/metrics_bridge.rs
+++ b/crates/scheduler/src/metrics_bridge.rs
@@ -61,13 +61,24 @@ where
     }
 
     pub async fn run(mut self, cancel: CancellationToken) -> Result<(), MetricsError> {
-        while !cancel.is_cancelled() {
-            if let Some((per_id, metrics)) = self.streams.next().await {
-                tracing::debug!("Forwarding metric");
-                self.connector
-                    .forward_metrics(per_id, metrics)
-                    .await
-                    .expect("Status forwarded");
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    break;
+                }
+                item = self.streams.next() => {
+                    match item {
+                        Some((per_id, metrics)) => {
+                            tracing::debug!("Forwarding metric");
+                            if let Err(e) = self.connector.forward_metrics(per_id, metrics).await {
+                                tracing::warn!("Failed to forward metrics: {}", e);
+                            }
+                        }
+                        None => {
+                            break;
+                        }
+                    }
+                }
             }
         }
         Ok(())

--- a/crates/scheduler/src/pool.rs
+++ b/crates/scheduler/src/pool.rs
@@ -191,6 +191,14 @@ impl Pool {
     }
 }
 
+impl Drop for Pool {
+    fn drop(&mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
 impl Stream for Pool {
     type Item = Result<WorkerDescriptor, PoolError>;
 

--- a/crates/scheduler/src/scheduling/data_scheduler.rs
+++ b/crates/scheduler/src/scheduling/data_scheduler.rs
@@ -60,7 +60,7 @@ where
         let d = self.dataset.clone();
         let data_provider = self.data_provider;
         let tracker = self.slice_tracker.clone();
-        let stream_handle = tokio::spawn({
+        let mut stream_handle = tokio::spawn({
             self.network
                 .on::<api::Codec, _>(move |req: &api::Request| {
                     matches!(
@@ -90,11 +90,13 @@ where
 
         let handle = tokio::spawn(async move {
             tokio::select! {
-                _ = stream_handle => {
+                _ = &mut stream_handle => {
                     tracing::info!("Data handler finished.");
                 },
                 _ = cancel_token.cancelled() => {
                     tracing::info!("Job is completed.");
+                    // NOTE: Cancelling the token should also abort the stream handler.
+                    stream_handle.abort();
                 }
             }
         });


### PR DESCRIPTION
Ensure batch scheduler and status bridge tasks are awaited/aborted, respect cancellation in the metrics bridge loop, abort pool tasks on drop, and cancel the data stream handler when jobs complete. This prevents the scheduler from freezing during shutdown.

Fixes #159