### PR TITLE
Support multiple data providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "nix 0.30.1",
  "ordered-float",
  "proptest",
+ "rand 0.9.2",
  "reqwest",
  "safetensors",
  "serde",
@@ -2633,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -3090,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -3104,9 +3105,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -4225,9 +4226,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
 dependencies = [
  "base64",
  "bytes",
@@ -5211,9 +5212,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,10 +68,11 @@ libp2p-stream = { version = "0.4.0-alpha" }
 libp2p-swarm-test = { version = "0.6.0", features = ["tokio"] }
 miette = { version = "7.6.0", features = ["fancy"] }
 mime = "0.3.17"
-mockall = "0.13.1"
+mockall = "0.14.0"
 nix = { version = "0.30.1", features = ["signal"] }
 pin-project = "1.1.7"
 proptest = "1.6.0"
+rand = "0.9.2"
 rayon = "1.11.0"
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }
 reqwest = { version = "0.12", default-features = false, features = ["stream", "json", "rustls-tls"] }

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -251,6 +251,14 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
 
     // Announce our dataset
     tracing::info!(dataset_name, "Announcing");
+    let _ = network.provide(dataset_name).await;
+
+    // Only a single record is stored for this key in the DHT.
+    // I.e. if there are multiple data providers with the same dataset,
+    // we might overwrite an existing record.
+    // For now, we assume that a dataset name is always used for the same record.
+    // With that assumption, overwriting existing records is okay.
+    // We might need to change this in the future.
     let _ = network
         .store(kad::Record::new(
             kad::RecordKey::new(&dataset_name),

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -804,7 +804,10 @@ pub mod data {
     /// Data server responds with data or error
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub enum Response {
-        Success { data_provider: PeerId, hash: String },
+        Success {
+            data_providers: Vec<PeerId>,
+            hash: String,
+        },
         NotFound,
         Error(String),
     }

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -1,6 +1,6 @@
 //! Scheduler binary.
 
-use std::{fs, sync::Arc, time::Duration};
+use std::{collections::HashSet, fs, sync::Arc, time::Duration};
 
 use clap::Parser;
 use figment::{
@@ -243,11 +243,11 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     let parameter_handle = parameter_pool.handle();
 
     let dataset = diloco_config.dataset.dataset.clone();
-    let (data_provider, dataset_record) = get_data_provider(&network, dataset.as_str()).await?;
+    let (data_providers, dataset_record) = get_data_providers(&network, dataset.as_str()).await?;
 
     let data_scheduler = DataScheduler::new(
         network.clone(),
-        data_provider,
+        data_providers,
         dataset.clone(),
         dataset_record.slice_hashes,
     );
@@ -480,26 +480,32 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
 }
 
 // Find the data provider for the requested dataset
-async fn get_data_provider(
+async fn get_data_providers(
     network: &Network,
     dataset: &str,
-) -> miette::Result<(PeerId, DataRecord)> {
-    let record = network.get(dataset).await.map_err(|e| {
+) -> miette::Result<(HashSet<PeerId>, DataRecord)> {
+    let providers = network.find_provider(dataset).await.map_err(|e| {
         miette::miette!("No data provider found for dataset \"{}\": {}", dataset, e)
     })?;
 
-    match record.publisher {
-        Some(data_provider) => match serde_json::from_slice(&record.value) {
-            Ok(dataset_record) => Ok((data_provider, dataset_record)),
-            Err(e) => Err(miette::miette!(
-                "Failed to parse dataset record for dataset \"{}\": {}",
-                dataset,
-                e
-            )),
-        },
-        None => Err(miette::miette!(
+    if providers.is_empty() {
+        return Err(miette::miette!(
             "No data provider found for dataset \"{}\"",
             dataset
+        ));
+    }
+
+    let record = network
+        .get(dataset)
+        .await
+        .map_err(|e| miette::miette!("No record found for dataset \"{}\": {}", dataset, e))?;
+
+    match serde_json::from_slice(&record.value) {
+        Ok(dataset_record) => Ok((providers, dataset_record)),
+        Err(e) => Err(miette::miette!(
+            "Failed to parse dataset record for dataset \"{}\": {}",
+            dataset,
+            e
         )),
     }
 }

--- a/crates/scheduler/src/scheduling/data_scheduler.rs
+++ b/crates/scheduler/src/scheduling/data_scheduler.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use hypha_messages::{api, data};
 use hypha_network::request_response::{
@@ -30,7 +30,7 @@ where
     TBehaviour: RequestResponseInterface<api::Codec> + Clone + Send + Sync + 'static,
 {
     network: TBehaviour,
-    data_provider: PeerId,
+    data_providers: HashSet<PeerId>,
     dataset: String,
     slice_tracker: Arc<Mutex<SliceTracker>>,
 }
@@ -41,13 +41,13 @@ where
 {
     pub fn new(
         network: TBehaviour,
-        data_provider: PeerId,
+        data_providers: HashSet<PeerId>,
         dataset: String,
         slice_hashes: Vec<String>,
     ) -> Self {
         Self {
             network,
-            data_provider,
+            data_providers,
             dataset,
             slice_tracker: Arc::new(Mutex::new(SliceTracker::new(slice_hashes))),
         }
@@ -58,7 +58,7 @@ where
         cancel_token: CancellationToken,
     ) -> Result<JoinHandle<()>, DataSchedulerError> {
         let d = self.dataset.clone();
-        let data_provider = self.data_provider;
+        let data_providers = Vec::from_iter(self.data_providers.iter().cloned());
         let tracker = self.slice_tracker.clone();
         let mut stream_handle = tokio::spawn({
             self.network
@@ -75,13 +75,14 @@ where
                 .map_err(DataSchedulerError::from)?
                 .respond_with_concurrent(None, move |request| {
                     let tracker = tracker.clone();
+                    let data_providers = data_providers.clone();
                     async move {
                         let peer_id = request.0;
                         tracing::debug!(%peer_id, "Received data slice request");
                         let hash = tracker.lock().await.next(&peer_id);
                         tracing::debug!(%peer_id, "Picked data slice {}", hash);
                         api::Response::Data(data::Response::Success {
-                            data_provider,
+                            data_providers,
                             hash,
                         })
                     }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -29,6 +29,7 @@ libp2p-stream.workspace = true
 miette.workspace = true
 nix.workspace = true
 ordered-float = "5"
+rand.workspace = true
 reqwest.workspace = true
 safetensors.workspace = true
 serde.workspace = true

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -28,6 +28,7 @@ use hypha_network::{
     stream_pull::StreamPullSenderInterface,
 };
 use libp2p::PeerId;
+use rand::seq::IndexedRandom;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
@@ -245,7 +246,7 @@ async fn fetch_resource(
         // otherwise we download it from a data provider.
         Reference::Scheduler { peer, dataset } => {
             tracing::debug!(peer_id = %peer, dataset, "Requesting data slice index from scheduler");
-            let (data_provider, hash) = Retry::spawn(retry_strategy.clone(), || {
+            let (data_providers, hash) = Retry::spawn(retry_strategy.clone(), || {
                 let network = state.network.clone();
                 async move {
                     match <Network as RequestResponseInterface<api::Codec>>::request(
@@ -258,9 +259,9 @@ async fn fetch_resource(
                     .await
                     {
                         Ok(api::Response::Data(data::Response::Success {
-                            data_provider,
+                            data_providers,
                             hash,
-                        })) => Ok((data_provider, hash)),
+                        })) => Ok((data_providers, hash)),
                         Ok(r) => Err(Error::Io(std::io::Error::other(format!(
                             "Unexpected response \"{:?}\"",
                             r
@@ -274,10 +275,11 @@ async fn fetch_resource(
             })
             .await?;
 
-            tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, hash, "Received slice index and data provider");
+            tracing::debug!(peer_id = %peer, data_peer_ids = ?data_providers, dataset, hash, "Received slice index and data provider");
 
             let out = Retry::spawn(retry_strategy, || {
                 let hash = hash.clone();
+                let data_providers = data_providers.clone();
                 let state = state.clone();
                 let dir_rel = "artifacts".to_string();
                 let mut out: Vec<FileResponse> = Vec::new();
@@ -293,7 +295,7 @@ async fn fetch_resource(
                         // Cache hit!
                         Ok(true) => {
                             tracing::debug!(
-                                peer_id = %peer, data_peer_id = %data_provider,
+                                peer_id = %peer, data_peer_ids = ?data_providers,
                                 dataset,
                                 hash,
                                 "File already exists, skipping data slice download"
@@ -308,7 +310,9 @@ async fn fetch_resource(
                         }
                         // Cache miss!
                         _ => {
-                            tracing::debug!(peer_id = %peer, data_peer_id = %data_provider, dataset, hash, "Downloading data slice");
+                            tracing::debug!(peer_id = %peer, data_peer_ids = ?data_providers, dataset, hash, "Downloading data slice");
+
+                            let data_provider = data_providers.choose(&mut rand::rng()).copied().ok_or_else(|| Error::Io(io::Error::other("no peers provided")))?;
 
                             let mut reader = state
                                 .network


### PR DESCRIPTION
Handle the case of multiple data providers providing the same dataset. For that case we assume that a dataset name is used uniquely for the same dataset. With that assumption, we can inform workers of the multiple data providers for a dataset and have them choose between them when downloading data slices. Right now, workers choose randomly if there are multiple data providers available.

Tested locally by having 2 data providers with the MNIST dataset. Workers pulled slices from both of them.

Remarks:
While this allows for simple load balancing when pull data, this won't provide any fault tolerance if data providers are no longer available: The scheduler determines the available data providers once. For fault tolerance, this needs to be done for each data slice request from workers. Furthermore, data providers add themselves into the DHT using [start_providing](https://docs.rs/libp2p-kad/latest/libp2p_kad/struct.Behaviour.html#method.start_providing). It'll take a while after a provider is gone that this record is removed from the DHT. We would have to account for this by checking the actual availability of data providers as reported by the DHT.