### PR TITLE
feat(data): add support for external addresses configuration

### DIFF
--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -21,9 +21,9 @@ use hypha_data::{
 };
 use hypha_messages::{DataRecord, health};
 use hypha_network::{
-    dial::DialInterface, kad::KademliaInterface, listen::ListenInterface,
-    request_response::RequestResponseInterfaceExt, stream_pull::StreamPullReceiverInterface,
-    swarm::SwarmDriver,
+    dial::DialInterface, external_address::ExternalAddressInterface, kad::KademliaInterface,
+    listen::ListenInterface, request_response::RequestResponseInterfaceExt,
+    stream_pull::StreamPullReceiverInterface, swarm::SwarmDriver,
 };
 use hypha_telemetry as telemetry;
 use libp2p::{Multiaddr, kad, multiaddr::Protocol};
@@ -135,6 +135,17 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     .into_diagnostic()?;
 
     tracing::info!("Successfully listening on all addresses");
+
+    // NOTE: Add configured external addresses (e.g., public IPs or DNS names)
+    // so peers can discover and connect to us.
+    join_all(
+        config
+            .external_addresses()
+            .iter()
+            .map(|address| network.add_external_address(address.clone()))
+            .collect::<Vec<_>>(),
+    )
+    .await;
 
     // Dial each gateway and, on success, set up a relay circuit listen via it.
     let gateway_peer_ids = Retry::spawn(

--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -73,6 +73,16 @@ pub struct Config {
     /// * "/ip4/0.0.0.0/udp/0/quic-v1" - QUIC on all interfaces, OS-assigned port
     listen_addresses: Vec<Multiaddr>,
 
+    /// External addresses to advertise for peer discovery (optional).
+    ///
+    /// Only advertise addresses that schedulers can reliably reach. Most workers rely on
+    /// relay circuits and don't need external addresses.
+    ///
+    /// Examples:
+    /// * "/ip4/203.0.113.30/tcp/9091"
+    /// * "/dns4/worker.example.com/tcp/9091"
+    external_addresses: Vec<Multiaddr>,
+
     /// Path to the dataset directory.
     ///
     /// Directory containing dataset files (slices) to serve to workers. Each file in the
@@ -214,6 +224,7 @@ impl Default for Config {
                     .parse()
                     .expect("default address parses into a Multiaddr"),
             ],
+            external_addresses: vec![],
             dataset_path: PathBuf::new(),
             exclude_cidr: reserved_cidrs(),
             relay_circuit: true,
@@ -234,6 +245,10 @@ impl Config {
 
     pub fn listen_addresses(&self) -> &Vec<Multiaddr> {
         &self.listen_addresses
+    }
+
+    pub fn external_addresses(&self) -> &Vec<Multiaddr> {
+        &self.external_addresses
     }
 
     /// Base directory for per-job working directories.

--- a/crates/data/src/network.rs
+++ b/crates/data/src/network.rs
@@ -5,6 +5,7 @@ use hypha_messages::{DataSlice, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
+    external_address::{ExternalAddressAction, ExternalAddressDriver, ExternalAddressInterface},
     kad::{KademliaAction, KademliaBehavior, KademliaDriver, KademliaInterface, PendingQueries},
     listen::{ListenAction, ListenDriver, ListenInterface, PendingListens},
     request_response::{
@@ -63,6 +64,7 @@ enum Action {
     Listen(ListenAction),
     Kademlia(KademliaAction),
     HealthRequestResponse(RequestResponseAction<health::Codec>),
+    ExternalAddress(ExternalAddressAction),
 }
 
 impl Network {
@@ -195,6 +197,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         Action::Kademlia(action) => self.process_kademlia_action(action).await,
                         Action::HealthRequestResponse(action) =>
                             <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_action(&mut self, action).await,
+                        Action::ExternalAddress(action) =>
+                            self.process_external_address_action(action).await,
                     }
                 }
                 else => break
@@ -240,6 +244,8 @@ impl ListenDriver<Behaviour> for NetworkDriver {
         &mut self.pending_listen_map
     }
 }
+
+impl ExternalAddressDriver<Behaviour> for NetworkDriver {}
 
 impl StreamPullInterface for Network {
     fn stream_control(&self) -> stream::Control {
@@ -312,5 +318,17 @@ impl RequestResponseInterface<health::Codec> for Network {
         self.action_sender
             .try_send(Action::HealthRequestResponse(action))
             .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
+    }
+}
+
+impl ExternalAddressInterface for Network {
+    async fn send(&self, action: ExternalAddressAction) {
+        if let Err(e) = self
+            .action_sender
+            .send(Action::ExternalAddress(action))
+            .await
+        {
+            tracing::error!(?e, "failed to send external address action");
+        }
     }
 }


### PR DESCRIPTION
- Update 'Config' to include 'external_addresses' field.
- Implement 'ExternalAddressInterface' for 'Network'.
- Register configured external addresses on startup in 'hypha-data' binary.
- This aligns 'hypha-data' network behavior with 'hypha-worker'.