### PR TITLE
feat(worker): revoke leases on failed tasks

### DIFF
--- a/crates/worker/src/arbiter.rs
+++ b/crates/worker/src/arbiter.rs
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     config::{OfferConfig, OfferStrategy},
+    executor::Status,
     job_manager::{JobManager, JobManagerError},
     lease_manager::{LeaseError, LeaseManager},
     network::Network,
@@ -100,6 +101,56 @@ where
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 interval.tick().await;
+
+                // NOTE: Cancel leases for finished jobs; assuming exactly one job per lease
+                let finished_jobs = job_manager
+                    .find_jobs_where(|job| {
+                        matches!(
+                            job.status,
+                            Status::Success | Status::Cancelled | Status::Failed(_)
+                        )
+                    })
+                    .await;
+
+                for job in finished_jobs {
+                    match job.status {
+                        Status::Failed(reason) => {
+                            tracing::warn!(
+                                job_id = %job.id,
+                                lease_id = %job.lease,
+                                reason = %reason,
+                                "Job failed, revoking lease"
+                            );
+
+                            if let Err(e) = lease_manager.remove(&job.lease).await {
+                                tracing::error!(
+                                    lease_id = %job.lease,
+                                    error = ?e,
+                                    "Failed to revoke lease for failed job"
+                                );
+                            }
+
+                            if let Err(error) = job_manager.cancel(&job.id).await {
+                                tracing::error!(
+                                    lease_id = %job.lease,
+                                    job_id = %job.id,
+                                    error = ?error,
+                                    "Failed to cancel (remove) finished job"
+                                );
+                            }
+                        }
+                        _ => {
+                            tracing::info!(
+                                job_id = %job.id,
+                                lease_id = %job.lease,
+                                status = ?job.status,
+                                "Job finished successfully"
+                            );
+                        }
+                    }
+                }
+
+                // NOTE: Cleanup expired leases and cancel linked jobs
                 if let Ok(expired) = lease_manager.proceed().await {
                     if expired.is_empty() {
                         continue;
@@ -113,23 +164,25 @@ where
 
                     for lease in expired {
                         let lease_id = lease.id;
-                        let job_ids = job_manager.find_jobs_by_lease(&lease_id).await;
+                        let jobs = job_manager
+                            .find_jobs_where(|job| job.lease == lease_id)
+                            .await;
 
-                        if job_ids.is_empty() {
+                        if jobs.is_empty() {
                             continue;
                         }
 
                         tracing::info!(
                             lease_id = %lease_id,
-                            jobs = ?job_ids,
+                            jobs = ?jobs,
                             "Cancelling jobs linked to expired lease"
                         );
 
-                        for job_id in job_ids {
-                            if let Err(error) = job_manager.cancel(&job_id).await {
+                        for job in jobs {
+                            if let Err(error) = job_manager.cancel(&job.id).await {
                                 tracing::error!(
                                     lease_id = %lease_id,
-                                    job_id = %job_id,
+                                    job_id = %job.id,
                                     error = ?error,
                                     "Failed to cancel job after lease expiry"
                                 );

--- a/crates/worker/src/executor/mod.rs
+++ b/crates/worker/src/executor/mod.rs
@@ -14,6 +14,14 @@ use uuid::Uuid;
 
 use crate::{connector::ConnectorError, executor::parameter_server::TensorOpError};
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum Status {
+    Running,
+    Success,
+    Failed(String),
+    Cancelled,
+}
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Bridge error: {0}")]
@@ -36,7 +44,6 @@ pub enum Error {
 }
 
 pub trait JobExecutor {
-    // NOTE: Avoid `async fn` in traits; return a boxed Future instead
     fn execute(
         &self,
         job: hypha_messages::JobSpec,
@@ -47,7 +54,6 @@ pub trait JobExecutor {
 }
 
 pub trait Execution {
-    // NOTE: Make object-safe by returning a boxed future.
-    // This allows storing heterogeneous Execution handles behind trait objects.
-    fn wait<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+    // NOTE: Make object-safe by returning a boxed future. This allows storing heterogeneous Execution handles behind trait objects.
+    fn wait<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<Status, Error>> + Send + 'a>>;
 }

--- a/crates/worker/src/executor/parameter_server.rs
+++ b/crates/worker/src/executor/parameter_server.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 use crate::{
     connector::Connector,
-    executor::{Error, Execution, JobExecutor},
+    executor::{Error, Execution, JobExecutor, Status},
     network::Network,
 };
 
@@ -56,14 +56,16 @@ pub struct ParameterServerExecutor {
     work_dir_base: PathBuf,
 }
 
+#[derive(Clone)]
 pub struct ParameterServerExecution {
     task_tracker: TaskTracker,
 }
 
 impl Execution for ParameterServerExecution {
-    fn wait<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+    fn wait<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<Status, Error>> + Send + 'a>> {
         Box::pin(async move {
             self.task_tracker.wait().await;
+            Ok(Status::Success)
         })
     }
 }

--- a/crates/worker/src/executor/process.rs
+++ b/crates/worker/src/executor/process.rs
@@ -11,15 +11,16 @@ use tokio::{
     fs,
     io::{AsyncBufReadExt, BufReader},
     process::Command,
+    sync::{Mutex, oneshot},
     time::sleep,
 };
-use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::{
     config::{ExecutorConfig, ExecutorRuntime},
     connector::Connector,
-    executor::{Error, Execution, JobExecutor, bridge::Bridge},
+    executor::{Error, Execution, JobExecutor, Status, bridge::Bridge},
     network::Network,
 };
 
@@ -31,13 +32,38 @@ pub struct ProcessExecutor {
 }
 
 pub struct ProcessExecution {
-    task_tracker: TaskTracker,
+    status_rx: Mutex<Option<oneshot::Receiver<Status>>>,
+}
+
+impl ProcessExecution {
+    fn new(status_rx: oneshot::Receiver<Status>) -> Self {
+        Self {
+            status_rx: Mutex::new(Some(status_rx)),
+        }
+    }
 }
 
 impl Execution for ProcessExecution {
-    fn wait<'a>(&'a self) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+    fn wait<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<Status, Error>> + Send + 'a>> {
         Box::pin(async move {
-            self.task_tracker.wait().await;
+            let rx = {
+                let mut guard = self.status_rx.lock().await;
+                guard.take()
+            }
+            .ok_or_else(|| {
+                Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Execution status already consumed",
+                ))
+            })?;
+
+            match rx.await {
+                Ok(status) => Ok(status),
+                Err(_) => Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "Execution task ended without status",
+                ))),
+            }
         })
     }
 }
@@ -137,9 +163,10 @@ impl JobExecutor for ProcessExecutor {
             .stdout(Stdio::piped());
         let mut process = process.spawn()?;
 
-        let task_tracker = TaskTracker::new();
+        let (status_tx, status_rx) = oneshot::channel();
         let shutdown = cancel.clone();
-        task_tracker.spawn(async move {
+
+        tokio::spawn(async move {
             let stdout = process.stdout.take().expect("stdout is available");
             let mut lines = BufReader::new(stdout).lines();
 
@@ -174,17 +201,39 @@ impl JobExecutor for ProcessExecutor {
                 }
             }
 
-            tokio::select! {
+            let exec_status = tokio::select! {
                 status = process.wait() => {
                     tracing::trace!(status = ?status, "Executor task exited");
-                }
-                _ = sleep(Duration::from_secs(5)) => {
-                    tracing::trace!("Executor task didn't exit in time, sending SIGKILL");
-                    if let Err(e) = process.kill().await {
-                        tracing::warn!(error = ?e, "Failed to send SIGKILL to executor process");
+
+                    match status {
+                        Ok(s) => {
+                            if shutdown.is_cancelled() {
+                                Status::Cancelled
+                            } else if s.success() {
+                                Status::Success
+                            } else {
+                                Status::Failed(format!("Process exited with status: {}", s))
+                            }
+                        }
+                        Err(e) => Status::Failed(format!("Wait failed: {}", e)),
                     }
                 }
-            }
+
+                _ = sleep(Duration::from_secs(5)) => {
+                    tracing::trace!("Executor didn't exit in time, sending SIGKILL");
+
+                    match process.kill().await {
+                        Ok(_) => Status::Cancelled, // Force killed
+                        Err(e) => {
+                            tracing::warn!(error = ?e, "Failed to send SIGKILL to executor");
+
+                            Status::Failed(format!("Force kill failed: {}", e))
+                        }
+                    }
+                }
+            };
+
+            let _ = status_tx.send(exec_status);
 
             shutdown.cancel();
             let _ = bridge.wait().await;
@@ -192,9 +241,7 @@ impl JobExecutor for ProcessExecutor {
             let _ = fs::remove_dir_all(&work_dir).await;
         });
 
-        task_tracker.close();
-
-        Ok(ProcessExecution { task_tracker })
+        Ok(ProcessExecution::new(status_rx))
     }
 }
 

--- a/crates/worker/src/job_manager.rs
+++ b/crates/worker/src/job_manager.rs
@@ -1,17 +1,17 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
-use hypha_messages::{Executor, ExecutorDescriptor, JobSpec, JobStatus};
+use hypha_messages::{Executor, ExecutorDescriptor, JobSpec};
 use hypha_network::request_response::RequestResponseError;
 use libp2p::PeerId;
 use thiserror::Error;
-use tokio::sync::Mutex;
+use tokio::{sync::Mutex, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::{
     config::{ExecutorConfig, ExecutorRuntime},
     connector::Connector,
-    executor::{self, Execution, JobExecutor, ParameterServerExecutor, ProcessExecutor},
+    executor::{self, Execution, JobExecutor, ParameterServerExecutor, ProcessExecutor, Status},
     network::Network,
 };
 
@@ -34,26 +34,52 @@ pub enum JobManagerError {
 }
 
 pub struct Job {
+    id: Uuid,
+    lease: Uuid,
+    scheduler: PeerId,
+    spec: JobSpec,
+    cancel_token: CancellationToken,
+    status: Status,
+    monitor: JoinHandle<()>,
+}
+
+impl Job {
+    fn status(&self) -> Status {
+        self.status.clone()
+    }
+
+    pub async fn cancel(self) -> Result<(), JobManagerError> {
+        tracing::debug!(job_id = %self.id, "Cancelling job");
+        self.cancel_token.cancel();
+        let _ = self.monitor.await;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct JobDescriptor {
     pub id: Uuid,
     pub lease: Uuid,
     pub scheduler: PeerId,
     pub spec: JobSpec,
-    pub cancel_token: CancellationToken,
-    pub execution: Box<dyn Execution + Sync + Send>,
+    pub status: Status,
 }
 
-impl Job {
-    pub async fn cancel(&self) -> Result<(), JobManagerError> {
-        tracing::debug!(job_id = %self.id, "Cancelling job");
-        self.cancel_token.cancel();
-        self.execution.wait().await;
-        Ok(())
+impl From<&Job> for JobDescriptor {
+    fn from(job: &Job) -> Self {
+        JobDescriptor {
+            id: job.id,
+            lease: job.lease,
+            scheduler: job.scheduler,
+            spec: job.spec.clone(),
+            status: job.status(),
+        }
     }
 }
 
 #[derive(Clone)]
 pub struct JobManager {
-    active_jobs: Arc<Mutex<HashMap<Uuid, Job>>>,
+    jobs: Arc<Mutex<HashMap<Uuid, Job>>>,
     connector: Connector<Network>,
     network: Network,
     work_dir_base: PathBuf,
@@ -68,7 +94,7 @@ impl JobManager {
         executor_configs: Vec<ExecutorConfig>,
     ) -> Self {
         Self {
-            active_jobs: Arc::new(Mutex::new(HashMap::new())),
+            jobs: Arc::new(Mutex::new(HashMap::new())),
             connector,
             network,
             work_dir_base,
@@ -113,15 +139,34 @@ impl JobManager {
                 let execution = executor
                     .execute(spec.clone(), cancel_token.clone(), spec.job_id, scheduler)
                     .await?;
+
+                let jobs = self.jobs.clone();
+                let monitor = tokio::spawn(async move {
+                    let status = match execution.wait().await {
+                        Ok(s) => s,
+                        Err(e) => Status::Failed(e.to_string()),
+                    };
+
+                    tracing::info!(job_id=%spec.job_id, status=?status, "Job completed");
+
+                    let mut guard = jobs.lock().await;
+                    if let Some(job) = guard.get_mut(&id) {
+                        job.status = status;
+                    }
+                });
+
                 let job = Job {
                     id,
                     lease,
                     scheduler,
                     spec: spec.clone(),
                     cancel_token: cancel_token.clone(),
-                    execution: Box::new(execution),
+                    status: Status::Running,
+                    monitor,
                 };
-                self.active_jobs.lock().await.insert(id, job);
+
+                self.jobs.lock().await.insert(id, job);
+
                 Ok(())
             }
             Executor::Aggregate(_) => {
@@ -143,15 +188,34 @@ impl JobManager {
                 let execution = executor
                     .execute(spec.clone(), cancel_token.clone(), spec.job_id, scheduler)
                     .await?;
+
+                let jobs = self.jobs.clone();
+                let monitor = tokio::spawn(async move {
+                    let status = match execution.wait().await {
+                        Ok(s) => s,
+                        Err(e) => Status::Failed(e.to_string()),
+                    };
+
+                    tracing::info!(job_id=%spec.job_id, status=?status, "Job completed");
+
+                    let mut guard = jobs.lock().await;
+                    if let Some(job) = guard.get_mut(&id) {
+                        job.status = status;
+                    }
+                });
+
                 let job = Job {
                     id,
                     lease,
                     scheduler,
                     spec: spec.clone(),
                     cancel_token: cancel_token.clone(),
-                    execution: Box::new(execution),
+                    status: Status::Running,
+                    monitor,
                 };
-                self.active_jobs.lock().await.insert(id, job);
+
+                self.jobs.lock().await.insert(id, job);
+
                 Ok(())
             }
         }
@@ -159,7 +223,7 @@ impl JobManager {
 
     pub async fn cancel(&mut self, job_id: &Uuid) -> Result<(), JobManagerError> {
         let job = {
-            let mut guard = self.active_jobs.lock().await;
+            let mut guard = self.jobs.lock().await;
             guard.remove(job_id)
         };
 
@@ -172,39 +236,28 @@ impl JobManager {
         }
     }
 
-    pub async fn find_jobs_by_lease(&self, lease_id: &Uuid) -> Vec<Uuid> {
-        self.active_jobs
+    pub async fn find_jobs_where<F>(&self, mut predicate: F) -> Vec<JobDescriptor>
+    where
+        F: FnMut(&JobDescriptor) -> bool,
+    {
+        self.jobs
             .lock()
             .await
             .values()
-            .filter_map(|job| (job.lease == *lease_id).then_some(job.id))
+            .filter_map(|job| {
+                let descriptor = job.into();
+                predicate(&descriptor).then_some(descriptor)
+            })
             .collect()
-    }
-
-    pub async fn find_jobs_by_scheduler(&self, scheduler: &PeerId) -> Vec<Uuid> {
-        self.active_jobs
-            .lock()
-            .await
-            .values()
-            .filter_map(|job| (job.scheduler == *scheduler).then_some(job.id))
-            .collect()
-    }
-
-    pub async fn get_status(&self, job_id: &Uuid) -> Result<JobStatus, JobManagerError> {
-        Err(JobManagerError::TaskNotFound(*job_id))
-    }
-
-    pub async fn cleanup_finished_jobs(&mut self) -> Vec<Uuid> {
-        Vec::new()
     }
 
     pub async fn shutdown(&mut self) {
         let jobs: Vec<Job> = {
-            let mut guard = self.active_jobs.lock().await;
+            let mut guard = self.jobs.lock().await;
             guard.drain().map(|(_, job)| job).collect()
         };
 
-        for job in jobs.iter() {
+        for job in jobs {
             let _ = job.cancel().await;
         }
     }


### PR DESCRIPTION
Move executors to a unified Status enum, so that task outcomes are observable. The arbiter uses     these statuses to discard leases when task (aka jobs) fail. This results in the scheduler re-allocating a worker for that tasks and then re-dispatching the it. This way a failure in an executor does not fail the training job. It assumes that there is just one task per lease.