### PR TITLE
improve filehash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +698,12 @@ name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1929,6 +1948,7 @@ dependencies = [
 name = "hypha-data"
 version = "0.0.0"
 dependencies = [
+ "blake3",
  "clap",
  "clap-markdown",
  "documented",
@@ -1945,7 +1965,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "tokio-retry",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ documented = "0.9.2"
 figment = { version = "0.10", features = ["toml", "env"] }
 futures-util = "0.3"
 http-body-util = "0.1.3"
+blake3 = "1.5"
 hypha-config = { path = "crates/config" }
 hypha-data = { path = "crates/data" }
 hypha-leases = { path = "crates/leases" }

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -22,11 +22,11 @@ miette.workspace = true
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sha2.workspace = true
 tokio.workspace = true
 tokio-retry.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+blake3.workspace = true
 
 [build-dependencies]
 clap.workspace = true

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -17,7 +17,7 @@ use figment::{
 use futures_util::{StreamExt, future::join_all};
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_data::{
-    config::Config, hash::get_file_sha256, network::Network, tensor_data::serialize_file,
+    config::Config, hash::get_file_hash, network::Network, tensor_data::serialize_file,
 };
 use hypha_messages::{DataRecord, health};
 use hypha_network::{
@@ -239,7 +239,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         dataset_files
             .par_iter()
             .map(|file| {
-                let hash = get_file_sha256(file);
+                let hash = get_file_hash(file);
                 hash.map(|h| (h, file.clone()))
             })
             .collect::<Result<Vec<_>, io::Error>>()

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -247,7 +247,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     .await
     .into_diagnostic()?
     .into_diagnostic()?;
-    let dataset_hashes: HashMap<String, PathBuf> = HashMap::from_iter(dataset_hashes);
+    let dataset_hashes: HashMap<u64, PathBuf> = HashMap::from_iter(dataset_hashes);
 
     // Announce our dataset
     tracing::info!(dataset_name, "Announcing");

--- a/crates/data/src/hash.rs
+++ b/crates/data/src/hash.rs
@@ -1,15 +1,15 @@
 use std::{fs::File, io, path::Path};
 
-use sha2::{Digest, Sha256};
+use blake3::Hasher;
 
-pub fn get_file_sha256<P>(path: P) -> io::Result<String>
+pub fn get_file_hash<P>(path: P) -> io::Result<String>
 where
     P: AsRef<Path>,
 {
     let mut file = File::open(path)?;
-    let mut hasher = Sha256::new();
+    let mut hasher = Hasher::new();
 
     let _n = io::copy(&mut file, &mut hasher)?;
     let hash = hasher.finalize();
-    Ok(format!("sha256:{:x}", hash))
+    Ok(format!("blake3:{}", hash.to_hex()))
 }

--- a/crates/data/src/hash.rs
+++ b/crates/data/src/hash.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io, path::Path};
 
 use blake3::Hasher;
 
-pub fn get_file_hash<P>(path: P) -> io::Result<String>
+pub fn get_file_hash<P>(path: P) -> io::Result<u64>
 where
     P: AsRef<Path>,
 {
@@ -11,5 +11,8 @@ where
 
     let _n = io::copy(&mut file, &mut hasher)?;
     let hash = hasher.finalize();
-    Ok(format!("blake3:{}", hash.to_hex()))
+
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&hash.as_bytes()[..8]);
+    Ok(u64::from_le_bytes(buf))
 }

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -806,7 +806,7 @@ pub mod data {
     pub enum Response {
         Success {
             data_providers: Vec<PeerId>,
-            hash: String,
+            hash: u64,
         },
         NotFound,
         Error(String),
@@ -822,11 +822,11 @@ pub struct ParameterStreamHeader {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataRecord {
-    pub slice_hashes: Vec<String>,
+    pub slice_hashes: Vec<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataSlice {
     pub dataset: String,
-    pub hash: String,
+    pub hash: u64,
 }

--- a/crates/scheduler/src/scheduling/data_scheduler.rs
+++ b/crates/scheduler/src/scheduling/data_scheduler.rs
@@ -43,7 +43,7 @@ where
         network: TBehaviour,
         data_providers: HashSet<PeerId>,
         dataset: String,
-        slice_hashes: Vec<String>,
+        slice_hashes: Vec<u64>,
     ) -> Self {
         Self {
             network,

--- a/crates/scheduler/src/tracker/slice.rs
+++ b/crates/scheduler/src/tracker/slice.rs
@@ -16,13 +16,13 @@ pub enum SliceError {
 
 #[derive(Debug, Clone)]
 pub struct Slice {
-    hash: String,
+    hash: u64,
     peer: Option<PeerId>,
     processed: bool,
 }
 
 impl Slice {
-    pub fn new(hash: String) -> Self {
+    pub fn new(hash: u64) -> Self {
         Slice {
             hash,
             peer: None,
@@ -34,12 +34,12 @@ impl Slice {
 /// This tracks the data slices provided by a data node.
 pub struct SliceTracker {
     slices: Vec<Slice>,
-    processing: HashMap<PeerId, String>,
+    processing: HashMap<PeerId, u64>,
     rounds: u32,
 }
 
 impl SliceTracker {
-    pub fn new(slice_hashes: Vec<String>) -> Self {
+    pub fn new(slice_hashes: Vec<u64>) -> Self {
         Self {
             slices: slice_hashes.into_iter().map(Slice::new).collect(),
             processing: HashMap::new(),
@@ -47,7 +47,7 @@ impl SliceTracker {
         }
     }
 
-    pub fn next(&mut self, peer: &PeerId) -> String {
+    pub fn next(&mut self, peer: &PeerId) -> u64 {
         let open_slice = self
             .slices
             .iter_mut()
@@ -58,8 +58,8 @@ impl SliceTracker {
             Some(slice) => {
                 slice.processed = true;
                 slice.peer = Some(*peer);
-                self.processing.insert(*peer, slice.hash.clone());
-                slice.hash.clone()
+                self.processing.insert(*peer, slice.hash);
+                slice.hash
             }
             None => {
                 // We use a cache stealing strategy. If a worker is slower, other workers can steal their cached data.
@@ -85,8 +85,8 @@ impl SliceTracker {
                             .expect("Slice");
                         slice.processed = true;
                         slice.peer = Some(*peer);
-                        self.processing.insert(*peer, slice.hash.clone());
-                        slice.hash.clone()
+                        self.processing.insert(*peer, slice.hash);
+                        slice.hash
                     }
                     None => {
                         tracing::info!("All slices have been processed. Start new round");
@@ -124,67 +124,51 @@ mod batch_scheduler_tests {
     async fn simple_scheduling() {
         let peer_1 = PeerId::random();
         let peer_2 = PeerId::random();
-        let slice_hashes = vec![
-            "0".to_string(),
-            "1".to_string(),
-            "2".to_string(),
-            "3".to_string(),
-            "4".to_string(),
-            "5".to_string(),
-            "6".to_string(),
-        ];
+        let slice_hashes = vec![0, 1, 2, 3, 4, 5, 6];
 
         let mut tracker = SliceTracker::new(slice_hashes);
 
-        assert_eq!(tracker.next(&peer_1), "0".to_string());
-        assert_eq!(tracker.next(&peer_2), "1".to_string());
-        assert_eq!(tracker.next(&peer_1), "2".to_string());
-        assert_eq!(tracker.next(&peer_2), "3".to_string());
-        assert_eq!(tracker.next(&peer_1), "4".to_string());
-        assert_eq!(tracker.next(&peer_2), "5".to_string());
-        assert_eq!(tracker.next(&peer_1), "6".to_string());
-        assert_eq!(tracker.next(&peer_2), "1".to_string());
-        assert_eq!(tracker.next(&peer_1), "0".to_string());
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 4);
+        assert_eq!(tracker.next(&peer_2), 5);
+        assert_eq!(tracker.next(&peer_1), 6);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_1), 0);
     }
 
     #[tokio::test]
     async fn fast_slow_scheduling() {
         let peer_1 = PeerId::random();
         let peer_2 = PeerId::random();
-        let slice_hashes = vec![
-            "0".to_string(),
-            "1".to_string(),
-            "2".to_string(),
-            "3".to_string(),
-            "4".to_string(),
-            "5".to_string(),
-            "6".to_string(),
-        ];
+        let slice_hashes = vec![0, 1, 2, 3, 4, 5, 6];
 
         let mut tracker = SliceTracker::new(slice_hashes);
 
         // Round 0
-        assert_eq!(tracker.next(&peer_1), "0".to_string());
-        assert_eq!(tracker.next(&peer_1), "1".to_string());
-        assert_eq!(tracker.next(&peer_1), "2".to_string());
-        assert_eq!(tracker.next(&peer_2), "3".to_string());
-        assert_eq!(tracker.next(&peer_1), "4".to_string());
-        assert_eq!(tracker.next(&peer_1), "5".to_string());
-        assert_eq!(tracker.next(&peer_1), "6".to_string());
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_1), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 4);
+        assert_eq!(tracker.next(&peer_1), 5);
+        assert_eq!(tracker.next(&peer_1), 6);
         // Round 1
-        assert_eq!(tracker.next(&peer_2), "3".to_string());
-        assert_eq!(tracker.next(&peer_1), "0".to_string());
-        assert_eq!(tracker.next(&peer_1), "1".to_string());
-        assert_eq!(tracker.next(&peer_1), "2".to_string());
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_1), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
         let slice = tracker.next(&peer_2);
-        let mut left_slices = vec!["4".to_string(), "5".to_string(), "6".to_string()];
+        let mut left_slices = vec![4, 5, 6];
         assert!(left_slices.contains(&slice));
         left_slices.retain(|f| f != &slice);
         assert!(left_slices.contains(&tracker.next(&peer_1)));
         assert!(left_slices.contains(&tracker.next(&peer_1)));
         // Round 2
-        assert_eq!(tracker.next(&peer_1), "0".to_string());
-        assert_eq!(tracker.next(&peer_2), "3".to_string());
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_2), 3);
         assert_eq!(tracker.rounds, 2);
     }
 
@@ -193,35 +177,27 @@ mod batch_scheduler_tests {
         let peer_1 = PeerId::random();
         let peer_2 = PeerId::random();
         let peer_3 = PeerId::random();
-        let slice_hashes = vec![
-            "0".to_string(),
-            "1".to_string(),
-            "2".to_string(),
-            "3".to_string(),
-            "4".to_string(),
-            "5".to_string(),
-            "6".to_string(),
-        ];
+        let slice_hashes = vec![0, 1, 2, 3, 4, 5, 6];
 
         let mut tracker = SliceTracker::new(slice_hashes);
 
         // Round 0
-        assert_eq!(tracker.next(&peer_1), "0".to_string());
-        assert_eq!(tracker.next(&peer_2), "1".to_string());
-        assert_eq!(tracker.next(&peer_1), "2".to_string());
-        assert_eq!(tracker.next(&peer_2), "3".to_string());
-        assert_eq!(tracker.next(&peer_1), "4".to_string());
-        assert_eq!(tracker.next(&peer_2), "5".to_string());
-        assert_eq!(tracker.next(&peer_1), "6".to_string());
+        assert_eq!(tracker.next(&peer_1), 0);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_1), 2);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_1), 4);
+        assert_eq!(tracker.next(&peer_2), 5);
+        assert_eq!(tracker.next(&peer_1), 6);
         tracker.remove_worker(&peer_1);
-        assert_eq!(tracker.next(&peer_3), "6".to_string());
+        assert_eq!(tracker.next(&peer_3), 6);
         // Round 1
-        assert_eq!(tracker.next(&peer_2), "0".to_string());
-        assert_eq!(tracker.next(&peer_3), "2".to_string());
-        assert_eq!(tracker.next(&peer_2), "1".to_string());
-        assert_eq!(tracker.next(&peer_3), "4".to_string());
-        assert_eq!(tracker.next(&peer_2), "3".to_string());
-        assert_eq!(tracker.next(&peer_3), "6".to_string());
-        assert_eq!(tracker.next(&peer_2), "5".to_string());
+        assert_eq!(tracker.next(&peer_2), 0);
+        assert_eq!(tracker.next(&peer_3), 2);
+        assert_eq!(tracker.next(&peer_2), 1);
+        assert_eq!(tracker.next(&peer_3), 4);
+        assert_eq!(tracker.next(&peer_2), 3);
+        assert_eq!(tracker.next(&peer_3), 6);
+        assert_eq!(tracker.next(&peer_2), 5);
     }
 }

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -58,7 +58,7 @@ pub enum Error {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Hash mismatch: expected {expected}, got {found}")]
-    HashMismatch { expected: String, found: String },
+    HashMismatch { expected: u64, found: u64 },
     #[error("Invalid job status: {0}")]
     InvalidStatus(String),
 }
@@ -278,7 +278,6 @@ async fn fetch_resource(
             tracing::debug!(peer_id = %peer, data_peer_ids = ?data_providers, dataset, hash, "Received slice index and data provider");
 
             let out = Retry::spawn(retry_strategy, || {
-                let hash = hash.clone();
                 let data_providers = data_providers.clone();
                 let state = state.clone();
                 let dir_rel = "artifacts".to_string();
@@ -287,7 +286,7 @@ async fn fetch_resource(
                     let dir_abs = safe_join(&state.work_dir, &dir_rel)?;
                     fs::create_dir_all(&dir_abs).await?;
 
-                    let file_name = hash.clone();
+                    let file_name = hash;
                     let rel = format!("{}/{}", dir_rel, file_name);
                     let abs = safe_join(&state.work_dir, &rel)?;
 
@@ -320,7 +319,7 @@ async fn fetch_resource(
                                     data_provider,
                                     &DataSlice {
                                         dataset: dataset.clone(),
-                                        hash: hash.clone(),
+                                        hash,
                                     },
                                 )
                                 .await.map_err(|e| Error::Connector(ConnectorError::OpenStream(e)))?;
@@ -341,7 +340,7 @@ async fn fetch_resource(
                                 fs::remove_file(&abs).await?;
 
                                 return Err(Error::HashMismatch {
-                                    expected: hash.clone(),
+                                    expected: hash,
                                     found: calculated_hash,
                                 });
                             }

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -17,7 +17,7 @@ use axum::{
     routing::{get, post},
 };
 use futures_util::{StreamExt, stream};
-use hypha_data::hash::get_file_sha256;
+use hypha_data::hash::get_file_hash;
 use hypha_messages::{
     DataSlice, Fetch, Receive, Reference, Send,
     action::{self, ActionRequest},
@@ -334,7 +334,7 @@ async fn fetch_resource(
                             file.sync_all().await?;
 
                             // Validate file against hash
-                            let calculated_hash = get_file_sha256(&abs)?;
+                            let calculated_hash = get_file_hash(&abs)?;
 
                             if calculated_hash != hash {
                                 // Delete file


### PR DESCRIPTION
Use the first 8 bytes of the blake3 digest as a u64 key so dataset records can hold far more slices within the same space limit while still serving as checksums for verification.