### PR TITLE
Use request/response for data records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,9 +2210,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2224,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -19,7 +19,7 @@ use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_tom
 use hypha_data::{
     config::Config, hash::get_file_sha256, network::Network, tensor_data::serialize_file,
 };
-use hypha_messages::{DataRecord, api, data_record, health};
+use hypha_messages::{DataRecord, data_record, health};
 use hypha_network::{
     dial::DialInterface, external_address::ExternalAddressInterface, kad::KademliaInterface,
     listen::ListenInterface, request_response::RequestResponseInterfaceExt,
@@ -254,7 +254,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
 
     let d = dataset_name.clone();
     let record_handle = network
-        .on::<api::Codec, _>(move |req: &api::Request| matches!(req, api::Request::DataRecord(_)))
+        .on::<data_record::Codec, _>(move |_: &data_record::Request| true)
         .into_stream()
         .await
         .into_diagnostic()?
@@ -264,19 +264,13 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
                 let d = d.clone();
                 let slice_hashes = dataset_hashes.keys().cloned().collect();
                 async move {
-                    if let api::Request::DataRecord(data_record::Request { dataset }) = request {
-                        if dataset == d {
-                            return api::Response::DataRecord(data_record::Response::Success {
-                                data_record: DataRecord { slice_hashes },
-                            });
-                        } else {
-                            return api::Response::DataRecord(data_record::Response::NotFound);
+                    if request.dataset == d {
+                        data_record::Response::Success {
+                            data_record: DataRecord { slice_hashes },
                         }
+                    } else {
+                        data_record::Response::NotFound
                     }
-
-                    api::Response::DataRecord(data_record::Response::Error(
-                        "Unexpected request".to_string(),
-                    ))
                 }
             }
         });

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -19,14 +19,14 @@ use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_tom
 use hypha_data::{
     config::Config, hash::get_file_sha256, network::Network, tensor_data::serialize_file,
 };
-use hypha_messages::{DataRecord, health};
+use hypha_messages::{DataRecord, api, data_record, health};
 use hypha_network::{
     dial::DialInterface, external_address::ExternalAddressInterface, kad::KademliaInterface,
     listen::ListenInterface, request_response::RequestResponseInterfaceExt,
     stream_pull::StreamPullReceiverInterface, swarm::SwarmDriver,
 };
 use hypha_telemetry as telemetry;
-use libp2p::{Multiaddr, kad, multiaddr::Protocol};
+use libp2p::{Multiaddr, multiaddr::Protocol};
 use miette::{IntoDiagnostic, Result};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tokio::{
@@ -220,7 +220,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     }
 
     let dataset_name = match dataset_path.file_name().and_then(|name| name.to_str()) {
-        Some(name) => Ok(name),
+        Some(name) => Ok(name.to_string()),
         None => Err(miette::miette!("Dataset path is not a directory")),
     }?;
     let dataset_files = match dataset_path.read_dir() {
@@ -251,31 +251,49 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
 
     // Announce our dataset
     tracing::info!(dataset_name, "Announcing");
-    let _ = network.provide(dataset_name).await;
 
-    // Only a single record is stored for this key in the DHT.
-    // I.e. if there are multiple data providers with the same dataset,
-    // we might overwrite an existing record.
-    // For now, we assume that a dataset name is always used for the same record.
-    // With that assumption, overwriting existing records is okay.
-    // We might need to change this in the future.
-    let _ = network
-        .store(kad::Record::new(
-            kad::RecordKey::new(&dataset_name),
-            serde_json::to_vec(&DataRecord {
-                slice_hashes: dataset_hashes.keys().cloned().collect(),
-            })
-            .map_err(|err| miette::miette!("Failed to serialize dataset record: {}", err))?,
-        ))
-        .await;
+    let d = dataset_name.clone();
+    let record_handle = network
+        .on::<api::Codec, _>(move |req: &api::Request| matches!(req, api::Request::DataRecord(_)))
+        .into_stream()
+        .await
+        .into_diagnostic()?
+        .respond_with_concurrent(None, {
+            let dataset_hashes = dataset_hashes.clone();
+            move |(_, request)| {
+                let d = d.clone();
+                let slice_hashes = dataset_hashes.keys().cloned().collect();
+                async move {
+                    if let api::Request::DataRecord(data_record::Request { dataset }) = request {
+                        if dataset == d {
+                            return api::Response::DataRecord(data_record::Response::Success {
+                                data_record: DataRecord { slice_hashes },
+                            });
+                        } else {
+                            return api::Response::DataRecord(data_record::Response::NotFound);
+                        }
+                    }
+
+                    api::Response::DataRecord(data_record::Response::Error(
+                        "Unexpected request".to_string(),
+                    ))
+                }
+            }
+        });
+
+    network
+        .provide(dataset_name.as_str())
+        .await
+        .into_diagnostic()?;
 
     let stream_pulls = network.streams_pull().expect("an unregistered pull stream").for_each_concurrent(None, {
         |(peer_id, resource, mut stream)| {
             let dataset_hashes = dataset_hashes.clone();
+            let dataset_name = dataset_name.clone();
             async move {
                 tracing::info!(peer_id = %peer_id, dataset = resource.dataset, slice = resource.hash, "Sending tensor to peer");
 
-                if dataset_name == resource.dataset.as_str() {
+                if dataset_name.as_str() == resource.dataset.as_str() {
                     // Use the provided hash to select a subset of the available dataset files.
                     match dataset_hashes.get(&resource.hash) {
                         None => {
@@ -315,6 +333,9 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         }
         _ = health_handle => {
             tracing::info!("Health handler terminated, shutting down");
+        }
+        _ = record_handle => {
+            tracing::info!("Data record handler terminated, shutting down");
         }
     }
 

--- a/crates/data/src/network.rs
+++ b/crates/data/src/network.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::StreamExt;
-use hypha_messages::{DataSlice, api, health};
+use hypha_messages::{DataSlice, data_record, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
@@ -42,7 +42,7 @@ pub struct Behaviour {
     stream: stream::Behaviour,
     kademlia: kad::Behaviour<kad::store::MemoryStore>,
     gossipsub: gossipsub::Behaviour,
-    request_response: request_response::Behaviour<api::Codec>,
+    data_record_request_response: request_response::Behaviour<data_record::Codec>,
     health_request_response: request_response::Behaviour<health::Codec>,
 }
 
@@ -53,9 +53,9 @@ pub struct NetworkDriver {
     pending_queries_map: PendingQueries,
     pending_bootstrap: Arc<SetOnce<()>>,
     action_receiver: mpsc::Receiver<Action>,
-    outbound_requests_map: OutboundRequests<api::Codec>,
-    outbound_responses_map: OutboundResponses,
-    request_handlers: Vec<RequestHandler<api::Codec>>,
+    data_record_outbound_requests_map: OutboundRequests<data_record::Codec>,
+    data_record_outbound_responses_map: OutboundResponses,
+    data_record_request_handlers: Vec<RequestHandler<data_record::Codec>>,
     health_outbound_requests_map: OutboundRequests<health::Codec>,
     health_outbound_responses_map: OutboundResponses,
     health_request_handlers: HealthRequestHandlers,
@@ -67,7 +67,7 @@ enum Action {
     Dial(DialAction),
     Listen(ListenAction),
     Kademlia(KademliaAction),
-    RequestResponse(RequestResponseAction<api::Codec>),
+    DataRecordRequestResponse(RequestResponseAction<data_record::Codec>),
     HealthRequestResponse(RequestResponseAction<health::Codec>),
     ExternalAddress(ExternalAddressAction),
 }
@@ -120,13 +120,14 @@ impl Network {
                         kad::store::MemoryStore::new(key.public().to_peer_id()),
                     ),
                     gossipsub,
-                    request_response: request_response::Behaviour::<api::Codec>::new(
-                        [(
-                            StreamProtocol::new(api::IDENTIFIER),
-                            request_response::ProtocolSupport::Full,
-                        )],
-                        request_response::Config::default(),
-                    ),
+                    data_record_request_response:
+                        request_response::Behaviour::<data_record::Codec>::new(
+                            [(
+                                StreamProtocol::new(data_record::IDENTIFIER),
+                                request_response::ProtocolSupport::Inbound,
+                            )],
+                            request_response::Config::default(),
+                        ),
                     health_request_response: request_response::Behaviour::<health::Codec>::new(
                         [(
                             StreamProtocol::new(health::IDENTIFIER),
@@ -152,9 +153,9 @@ impl Network {
                 pending_listen_map: HashMap::default(),
                 pending_queries_map: HashMap::default(),
                 pending_bootstrap: Arc::new(SetOnce::new()),
-                outbound_requests_map: HashMap::default(),
-                outbound_responses_map: HashMap::default(),
-                request_handlers: Vec::new(),
+                data_record_outbound_requests_map: HashMap::default(),
+                data_record_outbound_responses_map: HashMap::default(),
+                data_record_request_handlers: Vec::new(),
                 health_outbound_requests_map: HashMap::default(),
                 health_outbound_responses_map: HashMap::default(),
                 health_request_handlers: Vec::new(),
@@ -196,8 +197,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         SwarmEvent::Behaviour(BehaviourEvent::Dcutr(event)) => {
                             tracing::debug!("dcutr event: {:?}", event);
                         }
-                        SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(event)) => {
-                            <NetworkDriver as RequestResponseDriver<Behaviour, api::Codec>>::process_request_response_event(&mut self, event).await;
+                        SwarmEvent::Behaviour(BehaviourEvent::DataRecordRequestResponse(event)) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, data_record::Codec>>::process_request_response_event(&mut self, event).await;
                         }
                         SwarmEvent::Behaviour(BehaviourEvent::HealthRequestResponse(event)) => {
                             <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_event(&mut self, event).await;
@@ -213,8 +214,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         Action::Dial(action) => self.process_dial_action(action).await,
                         Action::Listen(action) => self.process_listen_action(action).await,
                         Action::Kademlia(action) => self.process_kademlia_action(action).await,
-                        Action::RequestResponse(action) =>
-                            <NetworkDriver as RequestResponseDriver<Behaviour, api::Codec>>::process_request_response_action(&mut self, action).await,
+                        Action::DataRecordRequestResponse(action) =>
+                            <NetworkDriver as RequestResponseDriver<Behaviour, data_record::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::HealthRequestResponse(action) =>
                             <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::ExternalAddress(action) =>
@@ -303,40 +304,40 @@ impl KademliaInterface for Network {
     }
 }
 
-impl RequestResponseBehaviour<api::Codec> for Behaviour {
-    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<api::Codec> {
-        &mut self.request_response
+impl RequestResponseBehaviour<data_record::Codec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<data_record::Codec> {
+        &mut self.data_record_request_response
     }
 }
 
-impl RequestResponseDriver<Behaviour, api::Codec> for NetworkDriver {
-    fn outbound_requests(&mut self) -> &mut OutboundRequests<api::Codec> {
-        &mut self.outbound_requests_map
+impl RequestResponseDriver<Behaviour, data_record::Codec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<data_record::Codec> {
+        &mut self.data_record_outbound_requests_map
     }
 
     fn outbound_responses(&mut self) -> &mut OutboundResponses {
-        &mut self.outbound_responses_map
+        &mut self.data_record_outbound_responses_map
     }
 
-    fn request_handlers(&mut self) -> &mut Vec<RequestHandler<api::Codec>> {
-        &mut self.request_handlers
+    fn request_handlers(&mut self) -> &mut Vec<RequestHandler<data_record::Codec>> {
+        &mut self.data_record_request_handlers
     }
 }
 
-impl RequestResponseInterface<api::Codec> for Network {
-    async fn send(&self, action: RequestResponseAction<api::Codec>) {
+impl RequestResponseInterface<data_record::Codec> for Network {
+    async fn send(&self, action: RequestResponseAction<data_record::Codec>) {
         self.action_sender
-            .send(Action::RequestResponse(action))
+            .send(Action::DataRecordRequestResponse(action))
             .await
             .expect("network driver is running");
     }
 
     fn try_send(
         &self,
-        action: RequestResponseAction<api::Codec>,
+        action: RequestResponseAction<data_record::Codec>,
     ) -> Result<(), RequestResponseError> {
         self.action_sender
-            .try_send(Action::RequestResponse(action))
+            .try_send(Action::DataRecordRequestResponse(action))
             .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
     }
 }

--- a/crates/data/src/network.rs
+++ b/crates/data/src/network.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::StreamExt;
-use hypha_messages::{DataSlice, health};
+use hypha_messages::{DataSlice, api, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
@@ -42,6 +42,7 @@ pub struct Behaviour {
     stream: stream::Behaviour,
     kademlia: kad::Behaviour<kad::store::MemoryStore>,
     gossipsub: gossipsub::Behaviour,
+    request_response: request_response::Behaviour<api::Codec>,
     health_request_response: request_response::Behaviour<health::Codec>,
 }
 
@@ -52,6 +53,9 @@ pub struct NetworkDriver {
     pending_queries_map: PendingQueries,
     pending_bootstrap: Arc<SetOnce<()>>,
     action_receiver: mpsc::Receiver<Action>,
+    outbound_requests_map: OutboundRequests<api::Codec>,
+    outbound_responses_map: OutboundResponses,
+    request_handlers: Vec<RequestHandler<api::Codec>>,
     health_outbound_requests_map: OutboundRequests<health::Codec>,
     health_outbound_responses_map: OutboundResponses,
     health_request_handlers: HealthRequestHandlers,
@@ -63,6 +67,7 @@ enum Action {
     Dial(DialAction),
     Listen(ListenAction),
     Kademlia(KademliaAction),
+    RequestResponse(RequestResponseAction<api::Codec>),
     HealthRequestResponse(RequestResponseAction<health::Codec>),
     ExternalAddress(ExternalAddressAction),
 }
@@ -115,6 +120,13 @@ impl Network {
                         kad::store::MemoryStore::new(key.public().to_peer_id()),
                     ),
                     gossipsub,
+                    request_response: request_response::Behaviour::<api::Codec>::new(
+                        [(
+                            StreamProtocol::new(api::IDENTIFIER),
+                            request_response::ProtocolSupport::Full,
+                        )],
+                        request_response::Config::default(),
+                    ),
                     health_request_response: request_response::Behaviour::<health::Codec>::new(
                         [(
                             StreamProtocol::new(health::IDENTIFIER),
@@ -140,6 +152,9 @@ impl Network {
                 pending_listen_map: HashMap::default(),
                 pending_queries_map: HashMap::default(),
                 pending_bootstrap: Arc::new(SetOnce::new()),
+                outbound_requests_map: HashMap::default(),
+                outbound_responses_map: HashMap::default(),
+                request_handlers: Vec::new(),
                 health_outbound_requests_map: HashMap::default(),
                 health_outbound_responses_map: HashMap::default(),
                 health_request_handlers: Vec::new(),
@@ -181,6 +196,9 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         SwarmEvent::Behaviour(BehaviourEvent::Dcutr(event)) => {
                             tracing::debug!("dcutr event: {:?}", event);
                         }
+                        SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(event)) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, api::Codec>>::process_request_response_event(&mut self, event).await;
+                        }
                         SwarmEvent::Behaviour(BehaviourEvent::HealthRequestResponse(event)) => {
                             <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_event(&mut self, event).await;
                         }
@@ -195,6 +213,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         Action::Dial(action) => self.process_dial_action(action).await,
                         Action::Listen(action) => self.process_listen_action(action).await,
                         Action::Kademlia(action) => self.process_kademlia_action(action).await,
+                        Action::RequestResponse(action) =>
+                            <NetworkDriver as RequestResponseDriver<Behaviour, api::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::HealthRequestResponse(action) =>
                             <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::ExternalAddress(action) =>
@@ -280,6 +300,44 @@ impl KademliaInterface for Network {
         if let Err(e) = self.action_sender.send(Action::Kademlia(action)).await {
             tracing::error!(?e, "failed to send kademlia action");
         }
+    }
+}
+
+impl RequestResponseBehaviour<api::Codec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<api::Codec> {
+        &mut self.request_response
+    }
+}
+
+impl RequestResponseDriver<Behaviour, api::Codec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<api::Codec> {
+        &mut self.outbound_requests_map
+    }
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses {
+        &mut self.outbound_responses_map
+    }
+
+    fn request_handlers(&mut self) -> &mut Vec<RequestHandler<api::Codec>> {
+        &mut self.request_handlers
+    }
+}
+
+impl RequestResponseInterface<api::Codec> for Network {
+    async fn send(&self, action: RequestResponseAction<api::Codec>) {
+        self.action_sender
+            .send(Action::RequestResponse(action))
+            .await
+            .expect("network driver is running");
+    }
+
+    fn try_send(
+        &self,
+        action: RequestResponseAction<api::Codec>,
+    ) -> Result<(), RequestResponseError> {
+        self.action_sender
+            .try_send(Action::RequestResponse(action))
+            .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
     }
 }
 

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -29,7 +29,6 @@ pub mod api {
         ParameterPull(parameter_pull::Request),
         ParameterPush(parameter_push::Request),
         Data(data::Request),
-        DataRecord(data_record::Request),
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -41,7 +40,6 @@ pub mod api {
         ParameterPull(parameter_pull::Response),
         ParameterPush(parameter_push::Response),
         Data(data::Response),
-        DataRecord(data_record::Response),
     }
 }
 
@@ -835,6 +833,10 @@ pub struct DataSlice {
 
 pub mod data_record {
     use super::*;
+
+    pub type Codec = CborCodec<Request, Response>;
+
+    pub const IDENTIFIER: &str = "/hypha-data-record/0.0.1";
 
     /// Worker requests data record from data provider
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -29,6 +29,7 @@ pub mod api {
         ParameterPull(parameter_pull::Request),
         ParameterPush(parameter_push::Request),
         Data(data::Request),
+        DataRecord(data_record::Request),
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -40,6 +41,7 @@ pub mod api {
         ParameterPull(parameter_pull::Response),
         ParameterPush(parameter_push::Response),
         Data(data::Response),
+        DataRecord(data_record::Response),
     }
 }
 
@@ -829,4 +831,22 @@ pub struct DataRecord {
 pub struct DataSlice {
     pub dataset: String,
     pub hash: String,
+}
+
+pub mod data_record {
+    use super::*;
+
+    /// Worker requests data record from data provider
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Request {
+        pub dataset: String,
+    }
+
+    /// Data provider responds with data record or error
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub enum Response {
+        Success { data_record: DataRecord },
+        NotFound,
+        Error(String),
+    }
 }

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -11,7 +11,7 @@ use futures_util::{StreamExt, future::join_all};
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_messages::{
     AggregateExecutorConfig, AggregateExecutorDescriptor, DataRecord, Fetch, JobSpec,
-    TrainExecutorConfig, TrainExecutorDescriptor, WorkerSpec, api, data_record, health,
+    TrainExecutorConfig, TrainExecutorDescriptor, WorkerSpec, data_record, health,
 };
 use hypha_network::{
     cert::identity_from_private_key, dial::DialInterface,
@@ -498,18 +498,16 @@ async fn get_data_providers(
     // If there are multiple data providers for the same dataset, request
     // its data record from the first one.
     match network
-        .request::<api::Codec>(
+        .request::<data_record::Codec>(
             *providers.iter().next().expect("a data provider"),
-            api::Request::DataRecord(data_record::Request {
+            data_record::Request {
                 dataset: dataset.to_string(),
-            }),
+            },
         )
         .await
     {
-        Ok(api::Response::DataRecord(data_record::Response::Success { data_record })) => {
-            Ok((providers, data_record))
-        }
-        Ok(api::Response::DataRecord(data_record::Response::NotFound)) => Err(miette::miette!(
+        Ok(data_record::Response::Success { data_record }) => Ok((providers, data_record)),
+        Ok(data_record::Response::NotFound) => Err(miette::miette!(
             "No data record found for dataset \"{}\"",
             dataset
         )),

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -11,7 +11,7 @@ use futures_util::{StreamExt, future::join_all};
 use hypha_config::{ConfigWithMetadata, ConfigWithMetadataTLSExt, builder, to_toml};
 use hypha_messages::{
     AggregateExecutorConfig, AggregateExecutorDescriptor, DataRecord, Fetch, JobSpec,
-    TrainExecutorConfig, TrainExecutorDescriptor, WorkerSpec, health,
+    TrainExecutorConfig, TrainExecutorDescriptor, WorkerSpec, api, data_record, health,
 };
 use hypha_network::{
     cert::identity_from_private_key, dial::DialInterface,
@@ -495,17 +495,33 @@ async fn get_data_providers(
         ));
     }
 
-    let record = network
-        .get(dataset)
+    // If there are multiple data providers for the same dataset, request
+    // its data record from the first one.
+    match network
+        .request::<api::Codec>(
+            *providers.iter().next().expect("a data provider"),
+            api::Request::DataRecord(data_record::Request {
+                dataset: dataset.to_string(),
+            }),
+        )
         .await
-        .map_err(|e| miette::miette!("No record found for dataset \"{}\": {}", dataset, e))?;
-
-    match serde_json::from_slice(&record.value) {
-        Ok(dataset_record) => Ok((providers, dataset_record)),
+    {
+        Ok(api::Response::DataRecord(data_record::Response::Success { data_record })) => {
+            Ok((providers, data_record))
+        }
+        Ok(api::Response::DataRecord(data_record::Response::NotFound)) => Err(miette::miette!(
+            "No data record found for dataset \"{}\"",
+            dataset
+        )),
         Err(e) => Err(miette::miette!(
-            "Failed to parse dataset record for dataset \"{}\": {}",
+            "Failed to request data record for dataset \"{}\": {}",
             dataset,
             e
+        )),
+        Ok(response) => Err(miette::miette!(
+            "Unexpected response to data record request for dataset \"{}\": {:?}",
+            dataset,
+            response
         )),
     }
 }

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
-use hypha_messages::{action, api, health};
+use hypha_messages::{action, api, data_record, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
@@ -60,6 +60,7 @@ pub struct Behaviour {
     request_response: request_response::Behaviour<api::Codec>,
     health_request_response: request_response::Behaviour<health::Codec>,
     action_request_response: request_response::Behaviour<action::Codec>,
+    data_record_request_response: request_response::Behaviour<data_record::Codec>,
 }
 
 pub struct NetworkDriver {
@@ -79,6 +80,9 @@ pub struct NetworkDriver {
     action_outbound_requests_map: OutboundRequests<action::Codec>,
     action_outbound_responses_map: OutboundResponses,
     action_request_handlers: ActionRequestHandlers,
+    data_record_outbound_requests_map: OutboundRequests<data_record::Codec>,
+    data_record_outbound_responses_map: OutboundResponses,
+    data_record_request_handlers: Vec<RequestHandler<data_record::Codec>>,
     exclude_cidrs: Vec<IpNet>,
 }
 
@@ -91,6 +95,7 @@ enum Action {
     RequestResponse(RequestResponseAction<api::Codec>),
     HealthRequestResponse(RequestResponseAction<health::Codec>),
     ActionRequestResponse(RequestResponseAction<action::Codec>),
+    DataRecordRequestResponse(RequestResponseAction<data_record::Codec>),
     ExternalAddress(ExternalAddressAction),
 }
 
@@ -172,6 +177,14 @@ impl Network {
                         )],
                         request_response::Config::default(),
                     ),
+                    data_record_request_response:
+                        request_response::Behaviour::<data_record::Codec>::new(
+                            [(
+                                StreamProtocol::new(data_record::IDENTIFIER),
+                                request_response::ProtocolSupport::Outbound,
+                            )],
+                            request_response::Config::default(),
+                        ),
                 }
             })
             .map_err(|_| {
@@ -200,6 +213,9 @@ impl Network {
                 action_outbound_requests_map: HashMap::default(),
                 action_outbound_responses_map: HashMap::default(),
                 action_request_handlers: Vec::new(),
+                data_record_outbound_requests_map: HashMap::default(),
+                data_record_outbound_responses_map: HashMap::default(),
+                data_record_request_handlers: Vec::new(),
                 action_receiver,
                 exclude_cidrs,
             },
@@ -244,10 +260,12 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                         SwarmEvent::Behaviour(BehaviourEvent::ActionRequestResponse(event)) => {
                             <NetworkDriver as RequestResponseDriver<Behaviour, action::Codec>>::process_request_response_event(&mut self, event).await;
                         }
+                        SwarmEvent::Behaviour(BehaviourEvent::DataRecordRequestResponse(event)) => {
+                            <NetworkDriver as RequestResponseDriver<Behaviour, data_record::Codec>>::process_request_response_event(&mut self, event).await;
+                        }
                         SwarmEvent::Behaviour(BehaviourEvent::Dcutr(event)) => {
                             tracing::debug!("dcutr event: {:?}", event);
                         }
-
                         _ => {
                             tracing::debug!("Unhandled event: {:?}", event);
                         }
@@ -273,6 +291,8 @@ impl SwarmDriver<Behaviour> for NetworkDriver {
                             <NetworkDriver as RequestResponseDriver<Behaviour, health::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::ActionRequestResponse(action) =>
                             <NetworkDriver as RequestResponseDriver<Behaviour, action::Codec>>::process_request_response_action(&mut self, action).await,
+                        Action::DataRecordRequestResponse(action) =>
+                            <NetworkDriver as RequestResponseDriver<Behaviour, data_record::Codec>>::process_request_response_action(&mut self, action).await,
                         Action::ExternalAddress(action) =>
                             self.process_external_address_action(action).await,
                     }
@@ -492,6 +512,44 @@ impl RequestResponseInterface<action::Codec> for Network {
     ) -> Result<(), RequestResponseError> {
         self.action_sender
             .try_send(Action::ActionRequestResponse(action))
+            .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
+    }
+}
+
+impl RequestResponseBehaviour<data_record::Codec> for Behaviour {
+    fn request_response(&mut self) -> &mut libp2p::request_response::Behaviour<data_record::Codec> {
+        &mut self.data_record_request_response
+    }
+}
+
+impl RequestResponseDriver<Behaviour, data_record::Codec> for NetworkDriver {
+    fn outbound_requests(&mut self) -> &mut OutboundRequests<data_record::Codec> {
+        &mut self.data_record_outbound_requests_map
+    }
+
+    fn outbound_responses(&mut self) -> &mut OutboundResponses {
+        &mut self.data_record_outbound_responses_map
+    }
+
+    fn request_handlers(&mut self) -> &mut Vec<RequestHandler<data_record::Codec>> {
+        &mut self.data_record_request_handlers
+    }
+}
+
+impl RequestResponseInterface<data_record::Codec> for Network {
+    async fn send(&self, action: RequestResponseAction<data_record::Codec>) {
+        self.action_sender
+            .send(Action::DataRecordRequestResponse(action))
+            .await
+            .expect("network driver is running");
+    }
+
+    fn try_send(
+        &self,
+        action: RequestResponseAction<data_record::Codec>,
+    ) -> Result<(), RequestResponseError> {
+        self.action_sender
+            .try_send(Action::DataRecordRequestResponse(action))
             .map_err(|_| RequestResponseError::Other("Failed to send action".to_string()))
     }
 }


### PR DESCRIPTION
Data providers announce their available dataset using the DHT. Schedulers need a list of data slices of a dataset (= data record) if that dataset will be used in a job. We used to store this data record in the DHT as well. But DHT values are restricted in size and a data record can become quite large for some datasets. This commit changes the current behavior to no longer store data records in DHT. Instead, a data provider provides a request/response API for schedulers to request a data record for a dataset. By using request/response, we're no longer limited in the size a data record can have.