### PR TITLE
Clean parameter shutdown on scheduler crash

### DIFF
--- a/crates/worker/src/executor/parameter_server.rs
+++ b/crates/worker/src/executor/parameter_server.rs
@@ -192,7 +192,7 @@ impl JobExecutor for ParameterServerExecutor {
                 loop {
                     tracing::debug!(job_id = %job_id, status = ?current_status, "Requesting next aggregate action");
 
-                    let action_response = match Retry::spawn(retry_strategy.clone(), || {
+                    let action_request = Retry::spawn(retry_strategy.clone(), || {
                         let status = current_status.clone();
                         let network = network.clone();
                         async move {
@@ -205,9 +205,17 @@ impl JobExecutor for ParameterServerExecutor {
                             )
                             .await
                         }
-                    })
-                    .await
-                    {
+                    });
+
+                    let action_result = tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        action_result = action_request => {
+                            action_result
+                        }
+
+                    };
+
+                    let action_response = match action_result {
                         Ok(resp) => resp,
                         Err(e) => {
                             tracing::warn!(job_id = %job_id, error = %e, status = ?current_status, "Failed to fetch next aggregate action");


### PR DESCRIPTION
If a scheduler is unreachable while a parameter server is trying to communicate with it, we would no longer be able to gracefully stop the parameter server executor. This has been resolved to ensure that cancellation tokens are respected when communicating with schedulers.

Remarks: We should revisit and refactor how we use cancellation tokens in executors. The current code has many different code paths that separately handle cancellation tokens, making it prone to bugs. This PR doesn't resolve that and further work is needed here.

Resolves #229 