### PR TITLE
feat: extend stream protocol with trailer ack

### DIFF
--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -31,6 +31,7 @@ use miette::{IntoDiagnostic, Result};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tokio::{
     fs,
+    io::AsyncWriteExt,
     signal::unix::{SignalKind, signal},
 };
 use tokio_retry::{
@@ -286,31 +287,48 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         .await
         .into_diagnostic()?;
 
-    let stream_pulls = network.streams_pull().expect("an unregistered pull stream").for_each_concurrent(None, {
-        |(peer_id, resource, mut stream)| {
-            let dataset_hashes = dataset_hashes.clone();
-            let dataset_name = dataset_name.clone();
-            async move {
-                tracing::info!(peer_id = %peer_id, dataset = resource.dataset, slice = resource.hash, "Sending tensor to peer");
+    let stream_pulls = network
+        .streams_pull()
+        .expect("an unregistered pull stream")
+        .for_each_concurrent(None, {
+            move |request| {
+                let dataset_hashes = dataset_hashes.clone();
+                let dataset_name = dataset_name.clone();
+                async move {
+                    let peer_id = request.peer_id();
+                    let resource = request.request().clone();
+                    tracing::info!(peer_id = %peer_id, dataset = resource.dataset, slice = resource.hash, "Sending tensor to peer");
 
-                if dataset_name.as_str() == resource.dataset.as_str() {
-                    // Use the provided hash to select a subset of the available dataset files.
-                    match dataset_hashes.get(&resource.hash) {
-                        None => {
-                            tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Invalid hash for dataset");
-                        }
-                        Some(dataset_slice) => {
-                            if let Err(e) = serialize_file(dataset_slice, &mut stream).await {
-                                tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to serialize dataset: {}", e);
-                            }
-                        },
+                    if dataset_name.as_str() != resource.dataset.as_str() {
+                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "No dataset found with that name");
+                        return;
                     }
-                } else {
-                    tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "No dataset found with that name");
+
+                    let Some(dataset_slice) = dataset_hashes.get(&resource.hash) else {
+                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Invalid hash for dataset");
+                        return;
+                    };
+
+                    let Ok(payload_len) = fs::metadata(dataset_slice).await.map(|m| m.len()) else {
+                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to stat dataset slice");
+                        return;
+                    };
+
+                    let Ok((_, _, mut stream)) = request.create_response(payload_len).await else {
+                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to announce payload length");
+                        return;
+                    };
+
+                    if let Err(e) = serialize_file(dataset_slice, &mut stream).await {
+                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to serialize dataset: {}", e);
+                    }
+
+                    if let Err(e) = stream.shutdown().await {
+                        tracing::warn!(peer_id = %peer_id, dataset = resource.dataset, "Failed to finalize stream: {}", e);
+                    }
                 }
             }
-        }
-    });
+        });
 
     let mut sigterm = signal(SignalKind::terminate()).into_diagnostic()?;
 

--- a/crates/network/src/stream_pull.rs
+++ b/crates/network/src/stream_pull.rs
@@ -6,13 +6,16 @@
 
 // TODO: Decide whether to model this as an abstract stream interface with the protocol identifier as an argument or
 
-use futures_util::{AsyncReadExt, AsyncWriteExt, Stream};
+use std::io;
+
+use futures_util::{Stream, StreamExt};
 use libp2p::{PeerId, StreamProtocol};
 use libp2p_stream::{AlreadyRegistered, Control, OpenStreamError};
 use serde::{Serialize, de::DeserializeOwned};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_stream::StreamExt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
+
+use crate::utils::{FixedAsyncRead, FixedAsyncWrite};
 
 /// The protocol identifier for Hypha's tensor streaming protocol.
 ///
@@ -20,12 +23,52 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 /// between peers. It follows the libp2p convention of using a path-like identifier.
 const TENSOR_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/hypha-tensor-stream/pull");
 
-/// The maximum size of the resource header in bytes.
+/// The maximum size of the request header in bytes.
 ///
-/// This constant defines the maximum size of the resource header that can be
+/// This constant defines the maximum size of the request header that can be
 /// deserialized from the stream. It is used to prevent excessive memory usage
 /// and potential denial-of-service attacks.
-const MAX_RESOURCE_HEADER_SIZE: u64 = 1024 * 1024;
+const MAX_REQUEST_HEADER_SIZE: u64 = 1024 * 1024;
+
+/// The fixed header length used for announcing payload size.
+const PAYLOAD_LENGTH_HEADER_SIZE: usize = size_of::<u64>();
+
+/// Pending pull stream that still needs a declared payload length.
+pub struct IncomingPullStream<T, W> {
+    peer_id: PeerId,
+    request: T,
+    stream: W,
+}
+
+impl<T, W> IncomingPullStream<T, W> {
+    /// Returns the peer that initiated the pull.
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    /// Returns the requested resource.
+    pub fn request(&self) -> &T {
+        &self.request
+    }
+}
+
+impl<T, W: AsyncWrite + Unpin> IncomingPullStream<T, W> {
+    /// Writes the payload length header and returns a length-checked writer.
+    pub async fn create_response(
+        self,
+        payload_len: u64,
+    ) -> io::Result<(PeerId, T, FixedAsyncWrite<W>)> {
+        let mut stream = self.stream;
+        stream.write_all(&payload_len.to_le_bytes()).await?;
+        stream.flush().await?;
+
+        Ok((
+            self.peer_id,
+            self.request,
+            FixedAsyncWrite::new(stream, payload_len),
+        ))
+    }
+}
 
 /// Base trait for accessing libp2p stream control functionality.
 /// Meant for pull data from a peer.
@@ -56,7 +99,7 @@ pub trait StreamPullReceiverInterface<T: DeserializeOwned>: StreamPullInterface 
     ///
     /// # Returns
     ///
-    /// * `Ok(IncomingStreams)` - A stream of incoming connections
+    /// * `Ok(Stream)` - A stream of incoming connections
     /// * `Err(AlreadyRegistered)` - The protocol was already registered
     ///
     /// # Errors
@@ -65,39 +108,46 @@ pub trait StreamPullReceiverInterface<T: DeserializeOwned>: StreamPullInterface 
     /// registered with the stream control.
     fn streams_pull(
         &self,
-    ) -> Result<impl Stream<Item = (PeerId, T, impl AsyncWrite)>, AlreadyRegistered> {
+    ) -> Result<
+        impl Stream<Item = IncomingPullStream<T, impl AsyncWrite + Unpin>> + Send,
+        AlreadyRegistered,
+    > {
         let incoming_streams = self
             .stream_control()
             .accept_with_limit(TENSOR_STREAM_PROTOCOL, Some(8))?
-            .then(|(peer_id, mut stream)| async move {
+            .filter_map(|(peer_id, stream)| async move {
+                let mut stream = stream.compat();
                 let mut resource_len = [0u8; 8];
                 if let Err(e) = stream.read_exact(&mut resource_len).await {
                     tracing::warn!("Failed to read resource header length: {}", e);
                     return None;
                 };
-                let resource_len = u64::from_le_bytes(resource_len);
+                let request_len = u64::from_le_bytes(resource_len);
 
-                if resource_len >= MAX_RESOURCE_HEADER_SIZE {
+                if request_len >= MAX_REQUEST_HEADER_SIZE {
                     tracing::warn!("Resource header length exceeds maximum");
                     return None;
                 }
 
-                let mut resource_bytes = vec![0; resource_len as usize];
+                let mut request_bytes = vec![0; request_len as usize];
 
-                if let Err(e) = stream.read_exact(&mut resource_bytes).await {
+                if let Err(e) = stream.read_exact(&mut request_bytes).await {
                     tracing::warn!("Failed to read resource header: {}", e);
                     return None;
                 };
 
-                match serde_json::from_slice(&resource_bytes) {
-                    Ok(resource) => Some((peer_id, resource, stream.compat())),
-                    Err(e) => {
+                serde_json::from_slice(&request_bytes)
+                    .map(|resource| IncomingPullStream {
+                        peer_id,
+                        request: resource,
+                        stream,
+                    })
+                    .map_err(|e| {
                         tracing::warn!("Failed to deserialize resource header: {}", e);
-                        None
-                    }
-                }
-            })
-            .map_while(|e| e);
+                        e
+                    })
+                    .ok()
+            });
 
         Ok(incoming_streams)
     }
@@ -123,38 +173,47 @@ pub trait StreamPullSenderInterface<T: Serialize + Send + Sync>:
     ///
     /// # Returns
     ///
-    /// * `Ok(Stream)` - A successfully opened stream to the peer
+    /// * `Ok(AsyncRead)` - A successfully opened reader from the peer
     /// * `Err(OpenStreamError)` - An error occurred during stream establishment
-    fn stream_pull(
+    fn open_pull_stream(
         &self,
         peer_id: PeerId,
-        resource: &T,
-    ) -> impl Future<Output = Result<impl AsyncRead + Send + 'static, OpenStreamError>> + Send {
+        request: &T,
+    ) -> impl Future<
+        Output = Result<FixedAsyncRead<impl AsyncRead + Send + Unpin + 'static>, OpenStreamError>,
+    > + Send {
         async move {
-            let mut stream = self
+            let stream = self
                 .stream_control()
                 .open_stream(peer_id, TENSOR_STREAM_PROTOCOL)
                 .await?;
+            let mut stream = stream.compat();
 
             // Assuming that we only pull a single stream from a peer at a time,
             // we can simply send the resource name here.
-            let resource_bytes = serde_json::to_vec(resource).expect("a serializable resource");
-            let resource_header = resource_bytes.len().to_le_bytes();
-            let bytes_written = stream.write(&resource_header).await?;
-            if bytes_written != resource_header.len() {
-                return Err(OpenStreamError::Io(std::io::Error::from(
-                    std::io::ErrorKind::UnexpectedEof,
-                )));
-            }
+            let request_bytes = serde_json::to_vec(request).expect("a serializable resource");
+            let request_header = request_bytes.len().to_le_bytes();
+            stream
+                .write_all(&request_header)
+                .await
+                .map_err(OpenStreamError::Io)?;
 
-            let bytes_written = stream.write(&resource_bytes).await?;
-            if bytes_written != resource_bytes.len() {
-                return Err(OpenStreamError::Io(std::io::Error::from(
-                    std::io::ErrorKind::UnexpectedEof,
-                )));
-            }
+            stream
+                .write_all(&request_bytes)
+                .await
+                .map_err(OpenStreamError::Io)?;
 
-            Ok(stream.compat())
+            stream.flush().await.map_err(OpenStreamError::Io)?;
+
+            let mut header = [0u8; PAYLOAD_LENGTH_HEADER_SIZE];
+            stream
+                .read_exact(&mut header)
+                .await
+                .map_err(OpenStreamError::Io)?;
+
+            let payload_len = u64::from_le_bytes(header);
+
+            Ok(FixedAsyncRead::new(stream, payload_len))
         }
     }
 }

--- a/crates/network/src/stream_push.rs
+++ b/crates/network/src/stream_push.rs
@@ -6,14 +6,22 @@
 
 // TODO: Decide whether to model this as an abstract stream interface with the protocol identifier as an argument or
 
-use libp2p::{PeerId, Stream, StreamProtocol};
-use libp2p_stream::{AlreadyRegistered, Control, IncomingStreams, OpenStreamError};
+use futures_util::{Stream, StreamExt};
+use libp2p::{PeerId, StreamProtocol};
+use libp2p_stream::{AlreadyRegistered, Control, OpenStreamError};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio_util::compat::FuturesAsyncReadCompatExt;
+
+use crate::utils::{FixedAsyncRead, FixedAsyncWrite};
 
 /// The protocol identifier for Hypha's tensor streaming protocol.
 ///
 /// This constant defines the libp2p protocol string used for tensor data streaming
 /// between peers. It follows the libp2p convention of using a path-like identifier.
-const TENSOR_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/hypha-tensor-stream/push");
+const TENSOR_STREAM_PROTOCOL: StreamProtocol = StreamProtocol::new("/hypha-tensor-stream/push/2");
+
+/// The fixed header length used for announcing payload size.
+const PAYLOAD_LENGTH_HEADER_SIZE: usize = size_of::<u64>();
 
 /// Base trait for accessing libp2p stream control functionality.
 /// Meant for pushing data from one peer to another.
@@ -39,21 +47,46 @@ pub trait StreamPushInterface {
 pub trait StreamPushReceiverInterface: StreamPushInterface {
     /// Accept incoming streams.
     ///
-    /// This method registers the streaming protocol and returns a stream
-    /// of incoming connections from other peers wanting to send data.
+    /// This method registers the streaming protocol and returns a stream of
+    /// framed incoming connections. The returned reader verifies a trailing
+    /// size marker and sends an ACK back to the sender before yielding EOF.
     ///
     /// # Returns
     ///
-    /// * `Ok(IncomingStreams)` - A stream of incoming connections
+    /// * `Ok(Stream)` - A stream of framed incoming connections
     /// * `Err(AlreadyRegistered)` - The protocol was already registered
     ///
     /// # Errors
     ///
     /// Returns [`AlreadyRegistered`] if the protocol has already been
     /// registered with the stream control.
-    fn streams_push(&self) -> Result<IncomingStreams, AlreadyRegistered> {
-        self.stream_control()
-            .accept_with_limit(TENSOR_STREAM_PROTOCOL, Some(8))
+    fn streams_push(
+        &self,
+    ) -> Result<
+        impl Stream<
+            Item = (
+                PeerId,
+                FixedAsyncRead<impl AsyncRead + Send + Unpin + 'static>,
+            ),
+        > + Send
+        + 'static,
+        AlreadyRegistered,
+    > {
+        let incoming = self
+            .stream_control()
+            .accept_with_limit(TENSOR_STREAM_PROTOCOL, Some(8))?
+            .filter_map(|(peer_id, stream)| async move {
+                let mut stream = stream.compat();
+                let mut header = [0u8; PAYLOAD_LENGTH_HEADER_SIZE];
+                if let Err(e) = stream.read_exact(&mut header).await {
+                    tracing::warn!("Failed to read push header: {}", e);
+                    return None;
+                }
+                let payload_len = u64::from_le_bytes(header);
+
+                Some((peer_id, FixedAsyncRead::new(stream, payload_len)))
+            });
+        Ok(incoming)
     }
 }
 
@@ -75,16 +108,29 @@ pub trait StreamPushSenderInterface: StreamPushInterface + Sync {
     ///
     /// # Returns
     ///
-    /// * `Ok(Stream)` - A successfully opened stream to the peer
+    /// * `Ok(AsyncWrite)` - A successfully opened writer to the peer
     /// * `Err(OpenStreamError)` - An error occurred during stream establishment
-    fn stream_push(
+    fn open_push_stream(
         &self,
         peer_id: PeerId,
-    ) -> impl Future<Output = Result<Stream, OpenStreamError>> + Send {
+        payload_len: u64,
+    ) -> impl Future<
+        Output = Result<FixedAsyncWrite<impl AsyncWrite + Send + Unpin + 'static>, OpenStreamError>,
+    > + Send {
         async move {
-            self.stream_control()
+            let stream = self
+                .stream_control()
                 .open_stream(peer_id, TENSOR_STREAM_PROTOCOL)
+                .await?;
+            let mut stream = stream.compat();
+
+            stream
+                .write_all(&payload_len.to_le_bytes())
                 .await
+                .map_err(OpenStreamError::Io)?;
+            stream.flush().await.map_err(OpenStreamError::Io)?;
+
+            Ok(FixedAsyncWrite::new(stream, payload_len))
         }
     }
 }

--- a/crates/network/src/utils.rs
+++ b/crates/network/src/utils.rs
@@ -1,6 +1,7 @@
 //! Utility functions.
 
 use std::{
+    io,
     net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
@@ -10,7 +11,10 @@ use std::{
 use futures_util::stream::Stream;
 use libp2p::multiaddr::{Error, Multiaddr, Protocol};
 use pin_project::pin_project;
-use tokio::time::{self, Sleep};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    time::{self, Sleep},
+};
 
 use crate::IpNet;
 
@@ -137,6 +141,154 @@ impl<S: Stream> Stream for Batched<S> {
                 }
             }
         }
+    }
+}
+
+/// Async reader that enforces an exact byte count.
+///
+/// Returns `UnexpectedEof` if the underlying stream ends before the declared length.
+#[pin_project]
+pub struct FixedAsyncRead<R> {
+    #[pin]
+    inner: R,
+    remaining: u64,
+}
+
+impl<R> FixedAsyncRead<R> {
+    /// Creates a new reader that enforces `expected_len` bytes.
+    pub fn new(inner: R, expected_len: u64) -> Self {
+        Self {
+            inner,
+            remaining: expected_len,
+        }
+    }
+
+    /// Returns the number of bytes left to read.
+    pub fn remaining(&self) -> u64 {
+        self.remaining
+    }
+
+    /// Returns the wrapped reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: AsyncRead> AsyncRead for FixedAsyncRead<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+
+        if *this.remaining == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let available = (*this.remaining).min(buf.remaining() as u64) as usize;
+        let mut limited = buf.take(available);
+
+        match this.inner.as_mut().poll_read(cx, &mut limited) {
+            Poll::Ready(Ok(())) => {
+                let read = limited.filled().len();
+                if read == 0 {
+                    return Poll::Ready(Err(io::Error::from(io::ErrorKind::UnexpectedEof)));
+                }
+
+                if read as u64 > *this.remaining {
+                    return Poll::Ready(Err(io::Error::from(io::ErrorKind::InvalidData)));
+                }
+
+                *this.remaining -= read as u64;
+                buf.advance(read);
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+/// Async writer that enforces an exact byte count.
+///
+/// Returns an error if more than the declared length is written, or if shutdown
+/// is attempted before the declared length is reached.
+#[pin_project]
+pub struct FixedAsyncWrite<W> {
+    #[pin]
+    inner: W,
+    remaining: u64,
+}
+
+impl<W> FixedAsyncWrite<W> {
+    /// Creates a new writer that enforces `expected_len` bytes.
+    pub fn new(inner: W, expected_len: u64) -> Self {
+        Self {
+            inner,
+            remaining: expected_len,
+        }
+    }
+
+    /// Returns the number of bytes left to write.
+    pub fn remaining(&self) -> u64 {
+        self.remaining
+    }
+
+    /// Returns the wrapped writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for FixedAsyncWrite<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut this = self.project();
+
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        if buf.len() as u64 > *this.remaining {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "write exceeds declared length",
+            )));
+        }
+
+        match this.inner.as_mut().poll_write(cx, buf) {
+            Poll::Ready(Ok(written)) => {
+                if written == 0 {
+                    return Poll::Ready(Ok(0));
+                }
+
+                if written as u64 > *this.remaining {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "write exceeds declared length",
+                    )));
+                }
+
+                *this.remaining -= written as u64;
+                Poll::Ready(Ok(written))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.project();
+        if *this.remaining > 0 {
+            return Poll::Ready(Err(io::Error::from(io::ErrorKind::UnexpectedEof)));
+        }
+        this.inner.poll_shutdown(cx)
     }
 }
 

--- a/crates/network/tests/stream_pull_test.rs
+++ b/crates/network/tests/stream_pull_test.rs
@@ -1,0 +1,339 @@
+use futures_util::{StreamExt, pin_mut};
+use hypha_network::stream_pull::{
+    StreamPullInterface, StreamPullReceiverInterface, StreamPullSenderInterface,
+};
+use libp2p::Swarm;
+use libp2p_stream as stream;
+use libp2p_swarm_test::SwarmExt;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TestResource {
+    dataset: String,
+}
+
+#[derive(Clone)]
+struct TestInterface {
+    control: stream::Control,
+}
+
+impl StreamPullInterface for TestInterface {
+    fn stream_control(&self) -> stream::Control {
+        self.control.clone()
+    }
+}
+
+impl StreamPullReceiverInterface<TestResource> for TestInterface {}
+impl StreamPullSenderInterface<TestResource> for TestInterface {}
+
+fn create_test_swarm() -> (Swarm<stream::Behaviour>, stream::Control) {
+    let mut control = None;
+    let swarm = Swarm::new_ephemeral_tokio(|_| {
+        let behaviour = stream::Behaviour::new();
+        control = Some(behaviour.new_control());
+        behaviour
+    });
+    (swarm, control.expect("stream control"))
+}
+
+struct TestDriver {
+    swarm: Swarm<stream::Behaviour>,
+    shutdown: CancellationToken,
+}
+
+impl TestDriver {
+    async fn run(mut self) {
+        loop {
+            tokio::select! {
+                _event = self.swarm.select_next_some() => {
+                    // No-op: we only need the behaviour polled.
+                },
+                _ = self.shutdown.cancelled() => break,
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn respond_pull_stream() {
+    let (mut swarm_requester, requester_control) = create_test_swarm();
+    let (mut swarm_provider, provider_control) = create_test_swarm();
+
+    swarm_requester.listen().with_memory_addr_external().await;
+    swarm_provider.listen().with_memory_addr_external().await;
+    swarm_requester.connect(&mut swarm_provider).await;
+
+    let provider_peer = *swarm_provider.local_peer_id();
+
+    let requester = TestInterface {
+        control: requester_control,
+    };
+    let provider = TestInterface {
+        control: provider_control,
+    };
+
+    let requester_shutdown = CancellationToken::new();
+    let provider_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_requester,
+            shutdown: requester_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_provider,
+            shutdown: provider_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    let provider_task = tokio::spawn(async move {
+        let incoming = provider.streams_pull().unwrap();
+        pin_mut!(incoming);
+        let incoming = incoming.next().await.expect("incoming pull stream");
+        let (_peer, resource, mut writer) = incoming.create_response(4).await.unwrap();
+        assert_eq!(resource.dataset, "demo");
+
+        writer.write_all(&[1, 2, 3, 4]).await.unwrap();
+        writer.shutdown().await.unwrap();
+    });
+
+    let requester_task = tokio::spawn(async move {
+        let mut reader = requester
+            .open_pull_stream(
+                provider_peer,
+                &TestResource {
+                    dataset: "demo".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 4];
+        reader.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, &[1, 2, 3, 4]);
+    });
+
+    requester_task.await.unwrap();
+    provider_task.await.unwrap();
+
+    requester_shutdown.cancel();
+    provider_shutdown.cancel();
+}
+
+#[tokio::test]
+async fn pull_under_send_errors_on_both_sides() {
+    let (mut swarm_requester, requester_control) = create_test_swarm();
+    let (mut swarm_provider, provider_control) = create_test_swarm();
+
+    swarm_requester.listen().with_memory_addr_external().await;
+    swarm_provider.listen().with_memory_addr_external().await;
+    swarm_requester.connect(&mut swarm_provider).await;
+
+    let provider_peer = *swarm_provider.local_peer_id();
+
+    let requester = TestInterface {
+        control: requester_control,
+    };
+    let provider = TestInterface {
+        control: provider_control,
+    };
+
+    let requester_shutdown = CancellationToken::new();
+    let provider_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_requester,
+            shutdown: requester_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_provider,
+            shutdown: provider_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    // Provider: accept incoming stream, announce length, then under-send.
+    let provider_task = tokio::spawn(async move {
+        let incoming = provider.streams_pull().unwrap();
+        pin_mut!(incoming);
+        let incoming = incoming.next().await.expect("incoming pull stream");
+        let (_peer, resource, mut writer) = incoming.create_response(5).await.unwrap();
+        assert_eq!(resource.dataset, "demo");
+
+        writer.write_all(&[9, 8, 7]).await.unwrap();
+        let err = writer.shutdown().await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    });
+
+    // Requester: initiate pull and expect an unexpected EOF while reading.
+    let requester_task = tokio::spawn(async move {
+        let mut reader = requester
+            .open_pull_stream(
+                provider_peer,
+                &TestResource {
+                    dataset: "demo".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 5];
+        let err = reader.read_exact(&mut buf).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    });
+
+    requester_task.await.unwrap();
+    provider_task.await.unwrap();
+
+    requester_shutdown.cancel();
+    provider_shutdown.cancel();
+}
+
+#[tokio::test]
+async fn pull_provider_aborts_requester_errors() {
+    let (mut swarm_requester, requester_control) = create_test_swarm();
+    let (mut swarm_provider, provider_control) = create_test_swarm();
+
+    swarm_requester.listen().with_memory_addr_external().await;
+    swarm_provider.listen().with_memory_addr_external().await;
+    swarm_requester.connect(&mut swarm_provider).await;
+
+    let provider_peer = *swarm_provider.local_peer_id();
+
+    let requester = TestInterface {
+        control: requester_control,
+    };
+    let provider = TestInterface {
+        control: provider_control,
+    };
+
+    let requester_shutdown = CancellationToken::new();
+    let provider_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_requester,
+            shutdown: requester_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_provider,
+            shutdown: provider_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    let provider_task = tokio::spawn(async move {
+        let incoming = provider.streams_pull().unwrap();
+        pin_mut!(incoming);
+        let incoming = incoming.next().await.expect("incoming pull stream");
+        let (_peer, _resource, writer) = incoming.create_response(4).await.unwrap();
+        drop(writer); // Drop immediately to simulate provider failure after announcing length.
+    });
+
+    let requester_task = tokio::spawn(async move {
+        let mut reader = requester
+            .open_pull_stream(
+                provider_peer,
+                &TestResource {
+                    dataset: "demo".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 4];
+        let err = reader.read_exact(&mut buf).await.unwrap_err();
+        assert!(
+            err.kind() == std::io::ErrorKind::UnexpectedEof
+                || err.kind() == std::io::ErrorKind::BrokenPipe
+        );
+    });
+
+    requester_task.await.unwrap();
+    provider_task.await.unwrap();
+
+    requester_shutdown.cancel();
+    provider_shutdown.cancel();
+}
+
+#[tokio::test]
+async fn pull_requester_aborts_provider_errors() {
+    let (mut swarm_requester, requester_control) = create_test_swarm();
+    let (mut swarm_provider, provider_control) = create_test_swarm();
+
+    swarm_requester.listen().with_memory_addr_external().await;
+    swarm_provider.listen().with_memory_addr_external().await;
+    swarm_requester.connect(&mut swarm_provider).await;
+
+    let provider_peer = *swarm_provider.local_peer_id();
+
+    let requester = TestInterface {
+        control: requester_control,
+    };
+    let provider = TestInterface {
+        control: provider_control,
+    };
+
+    let requester_shutdown = CancellationToken::new();
+    let provider_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_requester,
+            shutdown: requester_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_provider,
+            shutdown: provider_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    // Provider will get an error when writing because requester aborts early.
+    let provider_task = tokio::spawn(async move {
+        let incoming = provider.streams_pull().unwrap();
+        pin_mut!(incoming);
+        let incoming = incoming.next().await.expect("incoming pull stream");
+        let (_peer, _resource, mut writer) = incoming.create_response(4).await.unwrap();
+        let err = writer.write_all(&[1, 2, 3, 4]).await.unwrap_err();
+        assert!(
+            err.kind() == std::io::ErrorKind::BrokenPipe
+                || err.kind() == std::io::ErrorKind::UnexpectedEof
+        );
+    });
+
+    let requester_task = tokio::spawn(async move {
+        let _reader = requester
+            .open_pull_stream(
+                provider_peer,
+                &TestResource {
+                    dataset: "demo".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        // Drop reader immediately to simulate requester abort.
+    });
+
+    requester_task.await.unwrap();
+    provider_task.await.unwrap();
+
+    requester_shutdown.cancel();
+    provider_shutdown.cancel();
+}

--- a/crates/network/tests/stream_push_test.rs
+++ b/crates/network/tests/stream_push_test.rs
@@ -1,0 +1,286 @@
+use futures_util::{StreamExt, pin_mut};
+use hypha_network::stream_push::{
+    StreamPushInterface, StreamPushReceiverInterface, StreamPushSenderInterface,
+};
+use libp2p::Swarm;
+use libp2p_stream as stream;
+use libp2p_swarm_test::SwarmExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+struct TestInterface {
+    control: stream::Control,
+}
+
+impl StreamPushInterface for TestInterface {
+    fn stream_control(&self) -> stream::Control {
+        self.control.clone()
+    }
+}
+
+impl StreamPushReceiverInterface for TestInterface {}
+impl StreamPushSenderInterface for TestInterface {}
+
+fn create_test_swarm() -> (Swarm<stream::Behaviour>, stream::Control) {
+    let mut control = None;
+    let swarm = Swarm::new_ephemeral_tokio(|_| {
+        let behaviour = stream::Behaviour::new();
+        control = Some(behaviour.new_control());
+        behaviour
+    });
+    (swarm, control.expect("stream control"))
+}
+
+struct TestDriver {
+    swarm: Swarm<stream::Behaviour>,
+    shutdown: CancellationToken,
+}
+
+impl TestDriver {
+    async fn run(mut self) {
+        loop {
+            tokio::select! {
+                _event = self.swarm.select_next_some() => {
+                    // No-op: we only need the behaviour polled.
+                },
+                _ = self.shutdown.cancelled() => break,
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn push_succeeds_and_delivers_payload() {
+    let (mut swarm_sender, sender_control) = create_test_swarm();
+    let (mut swarm_receiver, receiver_control) = create_test_swarm();
+
+    swarm_sender.listen().with_memory_addr_external().await;
+    swarm_receiver.listen().with_memory_addr_external().await;
+    swarm_sender.connect(&mut swarm_receiver).await;
+
+    let receiver_peer = *swarm_receiver.local_peer_id();
+
+    let sender = TestInterface {
+        control: sender_control,
+    };
+    let receiver = TestInterface {
+        control: receiver_control,
+    };
+
+    let sender_shutdown = CancellationToken::new();
+    let receiver_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_sender,
+            shutdown: sender_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_receiver,
+            shutdown: receiver_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    let recv_task = tokio::spawn(async move {
+        let incoming = receiver.streams_push().unwrap();
+        pin_mut!(incoming);
+        let (_peer, mut reader) = incoming.next().await.expect("incoming stream");
+        let mut buf = [0u8; 4];
+        reader.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, &[1, 2, 3, 4]);
+    });
+
+    let send_task = tokio::spawn(async move {
+        let mut writer = sender.open_push_stream(receiver_peer, 4).await.unwrap();
+        writer.write_all(&[1, 2, 3, 4]).await.unwrap();
+        writer.shutdown().await.unwrap();
+    });
+
+    send_task.await.unwrap();
+    recv_task.await.unwrap();
+
+    sender_shutdown.cancel();
+    receiver_shutdown.cancel();
+}
+
+#[tokio::test]
+async fn push_under_sends_propagate_errors() {
+    let (mut swarm_sender, sender_control) = create_test_swarm();
+    let (mut swarm_receiver, receiver_control) = create_test_swarm();
+
+    swarm_sender.listen().with_memory_addr_external().await;
+    swarm_receiver.listen().with_memory_addr_external().await;
+    swarm_sender.connect(&mut swarm_receiver).await;
+
+    let receiver_peer = *swarm_receiver.local_peer_id();
+
+    let sender = TestInterface {
+        control: sender_control,
+    };
+    let receiver = TestInterface {
+        control: receiver_control,
+    };
+
+    let sender_shutdown = CancellationToken::new();
+    let receiver_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_sender,
+            shutdown: sender_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_receiver,
+            shutdown: receiver_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    // Receiver: accept the incoming stream and attempt to read the declared payload length.
+    let recv_task = tokio::spawn(async move {
+        let incoming = receiver.streams_push().unwrap();
+        pin_mut!(incoming);
+        let (_peer, mut reader) = incoming.next().await.expect("incoming stream");
+        let mut buf = [0u8; 4];
+        let err = reader.read_exact(&mut buf).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    });
+
+    // Sender: announce a 4-byte payload, send only 2 bytes, expect shutdown to error.
+    let send_task = tokio::spawn(async move {
+        let mut writer = sender.open_push_stream(receiver_peer, 4).await.unwrap();
+        writer.write_all(&[1, 2]).await.unwrap();
+        let err = writer.shutdown().await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    });
+
+    send_task.await.unwrap();
+    recv_task.await.unwrap();
+
+    sender_shutdown.cancel();
+    receiver_shutdown.cancel();
+}
+
+#[tokio::test]
+async fn push_receiver_aborts_sender_sees_error() {
+    let (mut swarm_sender, sender_control) = create_test_swarm();
+    let (mut swarm_receiver, receiver_control) = create_test_swarm();
+
+    swarm_sender.listen().with_memory_addr_external().await;
+    swarm_receiver.listen().with_memory_addr_external().await;
+    swarm_sender.connect(&mut swarm_receiver).await;
+
+    let receiver_peer = *swarm_receiver.local_peer_id();
+
+    let sender = TestInterface {
+        control: sender_control,
+    };
+    let receiver = TestInterface {
+        control: receiver_control,
+    };
+
+    let sender_shutdown = CancellationToken::new();
+    let receiver_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_sender,
+            shutdown: sender_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_receiver,
+            shutdown: receiver_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    let recv_task = tokio::spawn(async move {
+        let incoming = receiver.streams_push().unwrap();
+        pin_mut!(incoming);
+        let _ = incoming.next().await.expect("incoming stream");
+        // Drop without reading to simulate receiver failure.
+    });
+
+    let send_task = tokio::spawn(async move {
+        let mut writer = sender.open_push_stream(receiver_peer, 4).await.unwrap();
+        let err = writer.shutdown().await.unwrap_err();
+        assert!(
+            err.kind() == std::io::ErrorKind::BrokenPipe
+                || err.kind() == std::io::ErrorKind::UnexpectedEof
+        );
+    });
+
+    send_task.await.unwrap();
+    recv_task.await.unwrap();
+
+    sender_shutdown.cancel();
+    receiver_shutdown.cancel();
+}
+
+#[tokio::test]
+async fn push_sender_aborts_receiver_sees_error() {
+    let (mut swarm_sender, sender_control) = create_test_swarm();
+    let (mut swarm_receiver, receiver_control) = create_test_swarm();
+
+    swarm_sender.listen().with_memory_addr_external().await;
+    swarm_receiver.listen().with_memory_addr_external().await;
+    swarm_sender.connect(&mut swarm_receiver).await;
+
+    let receiver_peer = *swarm_receiver.local_peer_id();
+
+    let sender = TestInterface {
+        control: sender_control,
+    };
+    let receiver = TestInterface {
+        control: receiver_control,
+    };
+
+    let sender_shutdown = CancellationToken::new();
+    let receiver_shutdown = CancellationToken::new();
+
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_sender,
+            shutdown: sender_shutdown.clone(),
+        }
+        .run(),
+    );
+    tokio::spawn(
+        TestDriver {
+            swarm: swarm_receiver,
+            shutdown: receiver_shutdown.clone(),
+        }
+        .run(),
+    );
+
+    let recv_task = tokio::spawn(async move {
+        let incoming = receiver.streams_push().unwrap();
+        pin_mut!(incoming);
+        let (_peer, mut reader) = incoming.next().await.expect("incoming stream");
+        let mut buf = [0u8; 4];
+        let err = reader.read_exact(&mut buf).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    });
+
+    let send_task = tokio::spawn(async move {
+        let _ = sender.open_push_stream(receiver_peer, 4).await.unwrap();
+        // Drop without sending payload to simulate sender failure; receiver should error.
+    });
+
+    send_task.await.unwrap();
+    recv_task.await.unwrap();
+
+    sender_shutdown.cancel();
+    receiver_shutdown.cancel();
+}

--- a/crates/worker/src/connector/mod.rs
+++ b/crates/worker/src/connector/mod.rs
@@ -17,7 +17,11 @@ use libp2p_stream::{AlreadyRegistered, OpenStreamError};
 use reqwest;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::{compat::FuturesAsyncReadCompatExt, io::StreamReader};
+use tokio_retry::{
+    Retry,
+    strategy::{ExponentialBackoff, jitter},
+};
+use tokio_util::io::StreamReader;
 
 pub type BoxAsyncRead = Pin<Box<dyn AsyncRead + Send>>;
 pub type BoxAsyncWrite = Pin<Box<dyn AsyncWrite + Send + Unpin>>;
@@ -75,6 +79,7 @@ pub trait SendConnector: Send + Sync {
     fn send<'a>(
         &'a self,
         send: &'a SendRef,
+        payload_len: u64,
     ) -> Pin<Box<dyn Future<Output = Result<WriteItemStream, ConnectorError>> + Send + 'a>>;
 }
 
@@ -168,11 +173,15 @@ where
         Err(ConnectorError::UnsupportedFetch(r))
     }
 
-    pub async fn send(&self, send: SendRef) -> Result<WriteItemStream, ConnectorError> {
+    pub async fn send(
+        &self,
+        send: SendRef,
+        payload_len: u64,
+    ) -> Result<WriteItemStream, ConnectorError> {
         let r = send.as_ref().clone();
         for s in &self.senders {
             if s.supports(&r) {
-                return s.send(&send).await;
+                return s.send(&send, payload_len).await;
             }
         }
         Err(ConnectorError::UnsupportedSend(r))
@@ -329,6 +338,7 @@ where
     fn send<'a>(
         &'a self,
         send: &'a SendRef,
+        payload_len: u64,
     ) -> Pin<Box<dyn Future<Output = Result<WriteItemStream, ConnectorError>> + Send + 'a>> {
         Box::pin(async move {
             match send.as_ref() {
@@ -340,15 +350,38 @@ where
                         let it = futures_util::stream::iter(peers.clone()).then(move |peer| {
                             let network = network.clone();
                             async move {
-                                match network.stream_push(peer).await {
-                                    Ok(stream) => Ok(WriteItem {
+                                let retry_strategy =
+                                    ExponentialBackoff::from_millis(100).map(jitter).take(3);
+
+                                async fn attempt_push<T>(
+                                    network: T,
+                                    peer: PeerId,
+                                    payload_len: u64,
+                                ) -> Result<BoxAsyncWrite, ConnectorError>
+                                where
+                                    T: StreamPushSenderInterface,
+                                {
+                                    let writer = network
+                                        .open_push_stream(peer, payload_len)
+                                        .await
+                                        .map_err(ConnectorError::OpenStream)?;
+                                    Ok(Box::pin(writer))
+                                }
+
+                                let result = Retry::spawn(retry_strategy, move || {
+                                    attempt_push(network.clone(), peer, payload_len)
+                                })
+                                .await;
+
+                                match result {
+                                    Ok(writer) => Ok(WriteItem {
                                         meta: ItemMeta {
                                             kind: "peer",
                                             name: peer.to_string(),
                                         },
-                                        writer: Box::pin(stream.compat()),
+                                        writer,
                                     }),
-                                    Err(e) => Err(ConnectorError::OpenStream(e)),
+                                    Err(e) => Err(e),
                                 }
                             }
                         });
@@ -359,13 +392,13 @@ where
                             .first()
                             .copied()
                             .ok_or_else(|| io::Error::other("no peers provided"))?;
-                        let stream = self.network.stream_push(peer).await?;
+                        let writer = self.network.open_push_stream(peer, payload_len).await?;
                         let item = WriteItem {
                             meta: ItemMeta {
                                 kind: "peer",
                                 name: peer.to_string(),
                             },
-                            writer: Box::pin(stream.compat()),
+                            writer: Box::pin(writer),
                         };
                         let s = futures_util::stream::once(async move { Ok(item) });
                         Ok(Box::pin(s) as WriteItemStream)
@@ -404,7 +437,7 @@ where
                 } => {
                     let allow: Vec<PeerId> = peers.clone();
                     let incoming = self.network.streams_push()?;
-                    let stream = incoming.filter_map(move |(peer, s)| {
+                    let stream = incoming.filter_map(move |(peer, reader)| {
                         let allowed = allow.clone();
                         async move {
                             if allowed.is_empty() || allowed.iter().any(|p| p == &peer) {
@@ -413,7 +446,7 @@ where
                                         kind: "peer",
                                         name: peer.to_string(),
                                     },
-                                    reader: Box::pin(s.compat()),
+                                    reader: Box::pin(reader),
                                 };
                                 Some(Ok(item))
                             } else {

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -315,7 +315,7 @@ async fn fetch_resource(
 
                             let mut reader = state
                                 .network
-                                .stream_pull(
+                                .open_pull_stream(
                                     data_provider,
                                     &DataSlice {
                                         dataset: dataset.clone(),
@@ -416,10 +416,11 @@ async fn send_resource(
         let req = req.clone();
         async move {
             let abs = safe_join(&state.work_dir, &req.path)?;
-            let mut writers = state.connector.send(req.resource).await?;
-
             let cancel = state.cancel.clone();
             let file_path = abs.clone();
+            let metadata = fs::metadata(&file_path).await?;
+            let payload_len = metadata.len();
+            let mut writers = state.connector.send(req.resource, payload_len).await?;
 
             // Don't copy the resource in the background. We need to wait until its done.
             // If run in the background, the Python code never knows when the send
@@ -564,8 +565,8 @@ async fn receive_subscribe(
             let item = match item_result {
                 Ok(item) => item,
                 Err(err) => {
-                    tracing::error!(error = %err, path = %dir_rel_clone, "receive_subscribe: stream error");
-                    break;
+                    tracing::warn!(error = %err, path = %dir_rel_clone, "receive_subscribe: stream error");
+                    continue;
                 }
             };
             let (file_name, mut reader) = derive_name_and_reader(item, index);
@@ -574,7 +575,7 @@ async fn receive_subscribe(
                 Ok(p) => p,
                 Err(err) => {
                     tracing::error!(error = %err, file = %file_rel, "receive_subscribe: invalid target path");
-                    break;
+                    continue;
                 }
             };
             if let Some(parent) = file_abs.parent() {
@@ -582,7 +583,7 @@ async fn receive_subscribe(
                     Ok(()) => (),
                     Err(err) => {
                         tracing::error!(error = %err, directory = %parent.display(), "receive_subscribe: failed to create directory");
-                        break;
+                        continue;
                     }
                 }
             }
@@ -590,14 +591,14 @@ async fn receive_subscribe(
                 Ok(f) => f,
                 Err(err) => {
                     tracing::error!(error = %err, file = %file_abs.display(), "receive_subscribe: failed to create file");
-                    break;
+                    continue;
                 }
             };
             let size = match tokio::io::copy(&mut reader, &mut file).await {
                 Ok(n) => n,
                 Err(err) => {
-                    tracing::error!(error = %err, file = %file_abs.display(), "receive_subscribe: failed to copy resource");
-                    break;
+                    tracing::warn!(error = %err, file = %file_abs.display(), "receive_subscribe: failed to copy resource");
+                    continue;
                 }
             };
             if let Err(err) = file.sync_all().await {

--- a/crates/worker/src/executor/parameter_server.rs
+++ b/crates/worker/src/executor/parameter_server.rs
@@ -533,7 +533,8 @@ async fn broadcast_update(
     gradient_file: &Path,
     cancel: CancellationToken,
 ) -> Result<(), Error> {
-    let mut writers = connector.send(send).await?;
+    let payload_len = fs::metadata(gradient_file).await?.len();
+    let mut writers = connector.send(send, payload_len).await?;
 
     let mut set = JoinSet::new();
     let file_path = gradient_file.to_path_buf();


### PR DESCRIPTION
Adjust the stream protocol to include trailer ack so that we can _verify_ that _all_ data was streamed.