### PR TITLE
feat: add `NetworkConfig` with QUIC transport defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,7 +2486,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 [[package]]
 name = "libp2p"
 version = "0.56.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "bytes",
  "either",
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.6.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "libp2p-connection-limits"
 version = "0.6.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -2543,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.43.1"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "either",
  "fnv",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dcutr"
 version = "0.14.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.44.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "async-trait",
  "futures",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.49.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -2633,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.47.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -2672,7 +2672,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.48.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.48.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "hickory-proto",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.17.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.47.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.43.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "libp2p-quic"
 version = "0.13.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "ed25519-dalek",
  "futures",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "libp2p-relay"
 version = "0.21.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -2813,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "libp2p-request-response"
 version = "0.29.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "async-trait",
  "cbor4ii",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "libp2p-stream"
 version = "0.4.0-alpha"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.47.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "either",
  "fnv",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.1"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "heck",
  "quote",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-test"
 version = "0.6.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "async-trait",
  "futures",
@@ -2892,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.44.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.6.2"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "ed25519-dalek",
  "futures",
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.5.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "futures-timer",
@@ -2940,7 +2940,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.47.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "either",
  "futures",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "bytes",
  "futures",
@@ -3977,7 +3977,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4440,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls4#57747ea02e1486fd775a55d92e53b8f07cf398eb"
+source = "git+https://github.com/hypha-space/rust-libp2p?tag=v0.56.0-mtls5#89c70a6d3d3672e7310ea2cd37a3e15bdb567f42"
 dependencies = [
  "futures",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,8 @@ debug = true
 
 [patch.crates-io]
 # Patch 'libp2p' to enable mTLS support
-libp2p = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls4" }
-libp2p-quic = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls4" }
-libp2p-stream = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls4" }
-libp2p-swarm-test = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls4" }
-libp2p-tls = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls4" }
+libp2p = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls5" }
+libp2p-quic = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls5" }
+libp2p-stream = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls5" }
+libp2p-swarm-test = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls5" }
+libp2p-tls = { git = "https://github.com/hypha-space/rust-libp2p", tag = "v0.56.0-mtls5" }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -272,7 +272,7 @@
 //! [`miette`]: https://docs.rs/miette
 //! [`documented`]: https://docs.rs/documented
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use documented::{Documented, DocumentedFieldsOpt};
 use figment::{Figment, Provider, Source};
@@ -566,6 +566,69 @@ where
     }
     header.push('\n');
     Ok(header + &body)
+}
+
+/// QUIC/network tuning parameters shared across Hypha components.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Documented, DocumentedFieldsOpt)]
+pub struct NetworkConfig {
+    /// Estimated link bandwidth in megabits per second.
+    ///
+    /// Used to size QUIC flow-control windows (bandwidth-delay product).
+    /// Defaults to 1 Gbps to cover common DC and cloud links.
+    #[serde(default = "default_bandwidth_mbps")]
+    bandwidth_mbps: u64,
+
+    /// Expected round-trip time in milliseconds.
+    ///
+    /// Used with bandwidth to compute the bandwidth-delay product for flow control.
+    /// Defaults to 100 ms to cover cross-region deployments.
+    #[serde(default = "default_rtt_ms")]
+    rtt_ms: u64,
+
+    /// QUIC handshake timeout in seconds.
+    ///
+    /// Connections failing to complete the handshake within this deadline are aborted.
+    #[serde(default = "default_handshake_timeout")]
+    handshake_timeout: u64,
+}
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        Self {
+            bandwidth_mbps: default_bandwidth_mbps(),
+            rtt_ms: default_rtt_ms(),
+            handshake_timeout: default_handshake_timeout(),
+        }
+    }
+}
+
+impl NetworkConfig {
+    /// Estimated link bandwidth in megabits per second.
+    pub fn bandwidth_mbps(&self) -> u64 {
+        self.bandwidth_mbps
+    }
+
+    /// Estimated round-trip time in milliseconds.
+    pub fn rtt_ms(&self) -> u64 {
+        self.rtt_ms
+    }
+
+    /// QUIC handshake timeout as a Duration.
+    pub fn handshake_timeout(&self) -> Duration {
+        Duration::from_secs(self.handshake_timeout)
+    }
+}
+
+const fn default_bandwidth_mbps() -> u64 {
+    1_000
+}
+
+const fn default_rtt_ms() -> u64 {
+    100
+}
+
+const fn default_handshake_timeout() -> u64 {
+    30
 }
 
 /// Builder for creating layered configurations from multiple sources.

--- a/crates/data/src/bin/hypha-data.rs
+++ b/crates/data/src/bin/hypha-data.rs
@@ -101,9 +101,15 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     let ready = Arc::new(AtomicBool::new(false));
 
     // Load certificates and private key
-    let (network, network_driver) =
-        Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
-            .into_diagnostic()?;
+    let (network, network_driver) = Network::create(
+        cert_chain,
+        private_key,
+        ca_certs,
+        crls,
+        exclude_cidrs,
+        config.network(),
+    )
+    .into_diagnostic()?;
 
     let network_handle = tokio::spawn(network_driver.run());
 
@@ -394,6 +400,7 @@ async fn main() -> miette::Result<()> {
                 config.load_trust_chain()?,
                 config.load_crls()?,
                 exclude_cidrs,
+                config.network(),
             )
             .into_diagnostic()?;
             tokio::spawn(driver.run());

--- a/crates/data/src/config.rs
+++ b/crates/data/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
-use hypha_config::{ConfigError, ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use hypha_config::{ConfigError, ConfigWithMetadata, NetworkConfig, TLSConfig, ValidatableConfig};
 use hypha_network::{IpNet, find_containing_cidr, reserved_cidrs};
 use hypha_telemetry::{
     attributes::Attributes,
@@ -199,6 +199,14 @@ pub struct Config {
     /// significance. For high-throughput data nodes, 0.01-0.1 is probably sufficient.
     #[serde(alias = "traces_sampler_arg")]
     telemetry_sample_ratio: Option<f64>,
+
+    /// Network tuning for QUIC transport (bandwidth, RTT, handshake timeout).
+    ///
+    /// These values size QUIC flow-control windows using the bandwidth-delay product
+    /// and set the handshake timeout. Defaults target a 1 Gbps link with 100 ms RTT
+    /// and a 30s handshake deadline.
+    #[serde(default)]
+    network: NetworkConfig,
 }
 
 impl Default for Config {
@@ -234,6 +242,7 @@ impl Default for Config {
             telemetry_protocol: None,
             telemetry_sampler: None,
             telemetry_sample_ratio: None,
+            network: NetworkConfig::default(),
         }
     }
 }
@@ -289,6 +298,10 @@ impl Config {
     /// Optional traces sampler name.
     pub fn telemetry_sampler(&self) -> Option<SamplerKind> {
         self.telemetry_sampler.clone()
+    }
+
+    pub fn network(&self) -> &NetworkConfig {
+        &self.network
     }
 }
 

--- a/crates/data/src/network.rs
+++ b/crates/data/src/network.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::StreamExt;
+use hypha_config::NetworkConfig;
 use hypha_messages::{DataSlice, data_record, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
@@ -79,6 +80,7 @@ impl Network {
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
         exclude_cidrs: Vec<IpNet>,
+        network_config: &NetworkConfig,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
 
@@ -92,7 +94,24 @@ impl Network {
             .map_err(|_| {
                 SwarmError::TransportConfig("Failed to create TCP transport.".to_string())
             })?
-            .with_quic()
+            .with_quic_config(|mut c| {
+                // NOTE: Flow-control windows are sized from the configured bandwidth-delay product.
+                let bdp_bytes: u64 = (network_config.bandwidth_mbps() * 1_000_000 / 8)
+                    * network_config.rtt_ms()
+                    / 1000;
+
+                let max_stream_data =
+                    ((3_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+                let max_connection_data =
+                    ((4_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+
+                c.max_stream_data = max_stream_data;
+                c.max_connection_data = max_connection_data;
+                c.max_connection_send_data = Some(max_connection_data);
+                c.handshake_timeout = network_config.handshake_timeout();
+
+                c
+            })
             .with_dns()
             .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
             .with_relay_client(tls::Config::new, yamux::Config::default)

--- a/crates/gateway/src/bin/hypha-gateway.rs
+++ b/crates/gateway/src/bin/hypha-gateway.rs
@@ -84,9 +84,15 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
     let crls = config.load_crls()?;
 
     let exclude_cidrs = config.exclude_cidr().clone();
-    let (network, network_driver) =
-        Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
-            .into_diagnostic()?;
+    let (network, network_driver) = Network::create(
+        cert_chain,
+        private_key,
+        ca_certs,
+        crls,
+        exclude_cidrs,
+        config.network(),
+    )
+    .into_diagnostic()?;
     let mut driver_task = tokio::spawn(network_driver.run());
 
     // Register health handler responding with readiness
@@ -236,6 +242,7 @@ async fn main() -> Result<()> {
                 config.load_trust_chain()?,
                 config.load_crls()?,
                 exclude_cidrs,
+                config.network(),
             )
             .into_diagnostic()?;
             tokio::spawn(driver.run());

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
-use hypha_config::{ConfigError, ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use hypha_config::{ConfigError, ConfigWithMetadata, NetworkConfig, TLSConfig, ValidatableConfig};
 use hypha_network::{IpNet, find_containing_cidr, reserved_cidrs};
 use hypha_telemetry::{
     attributes::Attributes,
@@ -181,6 +181,14 @@ pub struct Config {
     /// Note: This only affects DHT address filtering, not direct peer connections.
     #[serde(default = "reserved_cidrs")]
     exclude_cidr: Vec<IpNet>,
+
+    /// Network tuning for QUIC transport (bandwidth, RTT, handshake timeout).
+    ///
+    /// These values size QUIC flow-control windows using the bandwidth-delay product
+    /// and set the handshake timeout. Defaults target a 1 Gbps link with 100 ms RTT
+    /// and a 30s handshake deadline.
+    #[serde(default)]
+    network: NetworkConfig,
 }
 
 impl Default for Config {
@@ -214,6 +222,7 @@ impl Default for Config {
             telemetry_sampler: None,
             telemetry_sample_ratio: None,
             exclude_cidr: reserved_cidrs(),
+            network: NetworkConfig::default(),
         }
     }
 }
@@ -259,6 +268,10 @@ impl Config {
 
     pub fn exclude_cidr(&self) -> &Vec<IpNet> {
         &self.exclude_cidr
+    }
+
+    pub fn network(&self) -> &NetworkConfig {
+        &self.network
     }
 }
 

--- a/crates/gateway/src/network.rs
+++ b/crates/gateway/src/network.rs
@@ -6,6 +6,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
+use hypha_config::NetworkConfig;
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
@@ -86,6 +87,7 @@ impl Network {
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
         exclude_cidrs: Vec<IpNet>,
+        network_config: &NetworkConfig,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
         let meter = metrics::global::meter();
@@ -101,7 +103,23 @@ impl Network {
                 .map_err(|_| {
                     SwarmError::TransportConfig("Failed to create TCP transport.".to_string())
                 })?
-                .with_quic()
+                .with_quic_config(|mut c| {
+                    // NOTE: Flow-control windows are sized from the configured bandwidth-delay product.
+                    let bdp_bytes: u64 = (network_config.bandwidth_mbps() * 1_000_000 / 8)
+                        * network_config.rtt_ms()
+                        / 1000;
+
+                    let max_stream_data =
+                        ((3_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+                    let max_connection_data =
+                        ((4_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+
+                    c.max_stream_data = max_stream_data;
+                    c.max_connection_data = max_connection_data;
+                    c.max_connection_send_data = Some(max_connection_data);
+                    c.handshake_timeout = network_config.handshake_timeout();
+                    c
+                })
                 .with_dns()
                 .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
                 .map_transport(|t| {

--- a/crates/inspect/src/bin/hypha-inspect.rs
+++ b/crates/inspect/src/bin/hypha-inspect.rs
@@ -74,9 +74,15 @@ async fn main() -> Result<()> {
 
             let exclude_cidrs = hypha_network::reserved_cidrs();
 
-            let (network, network_driver) =
-                Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
-                    .into_diagnostic()?;
+            let (network, network_driver) = Network::create(
+                cert_chain,
+                private_key,
+                ca_certs,
+                crls,
+                exclude_cidrs,
+                config.network(),
+            )
+            .into_diagnostic()?;
 
             let network_driver_task = tokio::spawn(network_driver.run());
 
@@ -156,9 +162,15 @@ async fn main() -> Result<()> {
 
             let exclude_cidrs = hypha_network::reserved_cidrs();
 
-            let (network, network_driver) =
-                Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
-                    .into_diagnostic()?;
+            let (network, network_driver) = Network::create(
+                cert_chain,
+                private_key,
+                ca_certs,
+                crls,
+                exclude_cidrs,
+                config.network(),
+            )
+            .into_diagnostic()?;
 
             let network_driver_task = tokio::spawn(network_driver.run());
 

--- a/crates/inspect/src/config.rs
+++ b/crates/inspect/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
-use hypha_config::{ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use hypha_config::{ConfigWithMetadata, NetworkConfig, TLSConfig, ValidatableConfig};
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 
@@ -54,6 +54,14 @@ pub struct Config {
     /// NOTE: Defaults to placeholder addresses so users must configure real endpoints.
     #[serde(alias = "gateways")]
     gateway_addresses: Vec<Multiaddr>,
+
+    /// Network tuning for QUIC transport (bandwidth, RTT, handshake timeout).
+    ///
+    /// These values size QUIC flow-control windows using the bandwidth-delay product
+    /// and set the handshake timeout. Defaults target a 1 Gbps link with 100 ms RTT
+    /// and a 30s handshake deadline.
+    #[serde(default)]
+    network: NetworkConfig,
 }
 
 impl Default for Config {
@@ -71,6 +79,7 @@ impl Default for Config {
                     .parse()
                     .expect("default address parses into a Multiaddr"),
             ],
+            network: NetworkConfig::default(),
         }
     }
 }
@@ -78,6 +87,10 @@ impl Default for Config {
 impl Config {
     pub fn gateway_addresses(&self) -> &Vec<Multiaddr> {
         &self.gateway_addresses
+    }
+
+    pub fn network(&self) -> &NetworkConfig {
+        &self.network
     }
 }
 

--- a/crates/inspect/src/network.rs
+++ b/crates/inspect/src/network.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
+use hypha_config::NetworkConfig;
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
     dial::{DialAction, DialDriver, DialInterface, PendingDials},
@@ -65,6 +66,7 @@ impl Network {
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
         exclude_cidrs: Vec<IpNet>,
+        network_config: &NetworkConfig,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
 
@@ -79,7 +81,23 @@ impl Network {
                 .map_err(|_| {
                     SwarmError::TransportConfig("Failed to create TCP transport.".to_string())
                 })?
-                .with_quic()
+                .with_quic_config(|mut c| {
+                    // NOTE: Flow-control windows are sized from the configured bandwidth-delay product.
+                    let bdp_bytes: u64 = (network_config.bandwidth_mbps() * 1_000_000 / 8)
+                        * network_config.rtt_ms()
+                        / 1000;
+
+                    let max_stream_data =
+                        ((3_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+                    let max_connection_data =
+                        ((4_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+
+                    c.max_stream_data = max_stream_data;
+                    c.max_connection_data = max_connection_data;
+                    c.max_connection_send_data = Some(max_connection_data);
+                    c.handshake_timeout = network_config.handshake_timeout();
+                    c
+                })
                 .with_dns()
                 .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
                 .with_behaviour(|key| Behaviour {

--- a/crates/scheduler/src/bin/hypha-scheduler.rs
+++ b/crates/scheduler/src/bin/hypha-scheduler.rs
@@ -108,9 +108,15 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
 
     let exclude_cidrs = config.exclude_cidr().clone();
 
-    let (network, network_driver) =
-        Network::create(cert_chain, private_key, ca_certs, crls, exclude_cidrs)
-            .into_diagnostic()?;
+    let (network, network_driver) = Network::create(
+        cert_chain,
+        private_key,
+        ca_certs,
+        crls,
+        exclude_cidrs,
+        config.network(),
+    )
+    .into_diagnostic()?;
     let mut driver_task = tokio::spawn(network_driver.run());
 
     join_all(
@@ -588,6 +594,7 @@ async fn main() -> Result<()> {
                 config.load_trust_chain()?,
                 config.load_crls()?,
                 exclude_cidrs,
+                config.network(),
             )
             .into_diagnostic()?;
             tokio::spawn(driver.run());

--- a/crates/scheduler/src/config.rs
+++ b/crates/scheduler/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
-use hypha_config::{ConfigError, ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use hypha_config::{ConfigError, ConfigWithMetadata, NetworkConfig, TLSConfig, ValidatableConfig};
 use hypha_network::{IpNet, find_containing_cidr, reserved_cidrs};
 use hypha_telemetry::{
     attributes::Attributes,
@@ -182,6 +182,14 @@ pub struct Config {
     /// Contains settings for resource allocation, job scheduling policies, and worker
     /// management strategies.
     scheduler: SchedulerConfig,
+
+    /// Network tuning for QUIC transport (bandwidth, RTT, handshake timeout).
+    ///
+    /// These values size QUIC flow-control windows using the bandwidth-delay product
+    /// and set the handshake timeout. Defaults target a 1 Gbps link with 100 ms RTT
+    /// and a 30s handshake deadline.
+    #[serde(default)]
+    network: NetworkConfig,
 }
 
 impl Default for Config {
@@ -220,6 +228,7 @@ impl Default for Config {
             telemetry_sampler: None,
             telemetry_sample_ratio: None,
             scheduler: SchedulerConfig::default(),
+            network: NetworkConfig::default(),
         }
     }
 }
@@ -273,6 +282,10 @@ impl Config {
 
     pub fn scheduler_config(&self) -> &SchedulerConfig {
         &self.scheduler
+    }
+
+    pub fn network(&self) -> &NetworkConfig {
+        &self.network
     }
 }
 

--- a/crates/scheduler/src/network.rs
+++ b/crates/scheduler/src/network.rs
@@ -6,6 +6,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
+use hypha_config::NetworkConfig;
 use hypha_messages::{action, api, data_record, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
@@ -106,6 +107,7 @@ impl Network {
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
         exclude_cidrs: Vec<IpNet>,
+        network_config: &NetworkConfig,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
         let meter = metrics::global::meter();
@@ -121,7 +123,23 @@ impl Network {
             .map_err(|_| {
                 SwarmError::TransportConfig("Failed to create TCP transport with mTLS.".to_string())
             })?
-            .with_quic()
+            .with_quic_config(|mut c| {
+                // NOTE: Flow-control windows are sized from the configured bandwidth-delay product.
+                let bdp_bytes: u64 = (network_config.bandwidth_mbps() * 1_000_000 / 8)
+                    * network_config.rtt_ms()
+                    / 1000;
+
+                let max_stream_data =
+                    ((3_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+                let max_connection_data =
+                    ((4_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+
+                c.max_stream_data = max_stream_data;
+                c.max_connection_data = max_connection_data;
+                c.max_connection_send_data = Some(max_connection_data);
+                c.handshake_timeout = network_config.handshake_timeout();
+                c
+            })
             .with_dns()
             .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
             .with_relay_client(tls::Config::new, yamux::Config::default)

--- a/crates/worker/src/bin/hypha-worker.rs
+++ b/crates/worker/src/bin/hypha-worker.rs
@@ -99,6 +99,7 @@ async fn run(config: ConfigWithMetadata<Config>) -> Result<()> {
         config.load_trust_chain()?,
         config.load_crls()?,
         exclude_cidrs,
+        config.network(),
     )
     .into_diagnostic()?;
 
@@ -340,6 +341,7 @@ async fn main() -> miette::Result<()> {
                 config.load_trust_chain()?,
                 config.load_crls()?,
                 exclude_cidrs,
+                config.network(),
             )
             .into_diagnostic()?;
 

--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use documented::{Documented, DocumentedFieldsOpt};
-use hypha_config::{ConfigError, ConfigWithMetadata, TLSConfig, ValidatableConfig};
+use hypha_config::{ConfigError, ConfigWithMetadata, NetworkConfig, TLSConfig, ValidatableConfig};
 use hypha_messages::ExecutorDescriptor;
 use hypha_network::{IpNet, find_containing_cidr, reserved_cidrs};
 use hypha_resources::Resources;
@@ -287,6 +287,14 @@ pub struct Config {
     /// addresses configured for direct connectivity.
     relay_circuit: bool,
 
+    /// Network tuning for QUIC transport (bandwidth, RTT, handshake timeout).
+    ///
+    /// These values size QUIC flow-control windows using the bandwidth-delay product
+    /// and set the handshake timeout. Defaults target a 1 Gbps link with 100 ms RTT
+    /// and a 30s handshake deadline.
+    #[serde(default)]
+    network: NetworkConfig,
+
     /// Base directory for per-job working directories.
     ///
     /// Each job gets a unique subdirectory named hypha-{job_uuid} containing downloaded
@@ -421,6 +429,7 @@ impl Default for Config {
             // NOTE: Enabled by default to support inbound connectivity via relays
             // when behind NAT or firewall.
             relay_circuit: true,
+            network: NetworkConfig::default(),
             // NOTE: Default work directory base. Jobs create subdirs `hypha-{uuid}` under this path.
             work_dir: PathBuf::from("/tmp"),
             resources: ResourceConfig::default(),
@@ -507,6 +516,10 @@ impl Config {
     /// Whether to listen via a relay P2pCircuit through the gateway.
     pub fn relay_circuit(&self) -> bool {
         self.relay_circuit
+    }
+
+    pub fn network(&self) -> &NetworkConfig {
+        &self.network
     }
 
     pub fn resources(&self) -> Resources {

--- a/crates/worker/src/network.rs
+++ b/crates/worker/src/network.rs
@@ -7,6 +7,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::stream::StreamExt;
+use hypha_config::NetworkConfig;
 use hypha_messages::{DataSlice, action, api, health};
 use hypha_network::{
     CertificateDer, CertificateRevocationListDer, IpNet, PrivateKeyDer,
@@ -100,6 +101,7 @@ impl Network {
         ca_certs: Vec<CertificateDer<'static>>,
         crls: Vec<CertificateRevocationListDer<'static>>,
         exclude_cidrs: Vec<IpNet>,
+        network_config: &NetworkConfig,
     ) -> Result<(Self, NetworkDriver), SwarmError> {
         let (action_sender, action_receiver) = mpsc::channel(5);
         let meter = metrics::global::meter();
@@ -114,7 +116,24 @@ impl Network {
             .map_err(|_| {
                 SwarmError::TransportConfig("Failed to create TCP transport.".to_string())
             })?
-            .with_quic()
+            .with_quic_config(|mut c| {
+                // NOTE: Flow-control windows are sized from the configured bandwidth-delay product.
+                let bdp_bytes: u64 = (network_config.bandwidth_mbps() * 1_000_000 / 8)
+                    * network_config.rtt_ms()
+                    / 1000;
+
+                let max_stream_data =
+                    ((3_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+                let max_connection_data =
+                    ((4_u64 * bdp_bytes).next_power_of_two()).min(u32::MAX as u64) as u32;
+
+                c.max_stream_data = max_stream_data;
+                c.max_connection_data = max_connection_data;
+                c.max_connection_send_data = Some(max_connection_data);
+                c.handshake_timeout = network_config.handshake_timeout();
+
+                c
+            })
             .with_dns()
             .map_err(|_| SwarmError::TransportConfig("Failed to setup DNS".to_string()))?
             .with_relay_client(tls::Config::new, yamux::Config::default)


### PR DESCRIPTION
Introduce a reusable `NetworkConfig` (defaults: 1 Gbps, 100 ms RTT, 30s handshake) and thread it through all configs so QUIC flow-control/handshake parameters are configurable via the new `[network]` block.