### PR TITLE
feat: worker can rejoin

### DIFF
--- a/crates/messages/src/lib.rs
+++ b/crates/messages/src/lib.rs
@@ -94,6 +94,7 @@ pub mod action {
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(tag = "state", rename_all = "kebab-case")]
     pub enum TrainStatus {
+        Joined,
         Idle,
         BatchCompleted {
             batch_size: u32,
@@ -104,6 +105,9 @@ pub mod action {
         },
         AppliedUpdate,
         PushedToHub,
+        SentModel,
+        ReceivedModel,
+        WaitedForModel,
         Terminated,
         Error(TrainError),
     }
@@ -148,6 +152,17 @@ pub mod action {
     #[serde(tag = "kind", rename_all = "kebab-case")]
     pub enum TrainAction {
         Idle {
+            timeout: SystemTime,
+        },
+        WaitForModel {
+            timeout: SystemTime,
+        },
+        ReceiveModel {
+            source: Reference,
+            timeout: SystemTime,
+        },
+        SendModel {
+            target: Reference,
             timeout: SystemTime,
         },
         ExecuteBatch,

--- a/crates/scheduler/src/scheduling/batch_scheduler.rs
+++ b/crates/scheduler/src/scheduling/batch_scheduler.rs
@@ -55,6 +55,8 @@ struct TrainingState {
     update_target: u32,
     counter: u32,
     peer_updates: HashMap<PeerId, u32>,
+    worker_without_model: Vec<PeerId>,
+    receive_from: HashMap<PeerId, PeerId>,
 }
 
 impl TrainingState {
@@ -63,6 +65,8 @@ impl TrainingState {
             update_target,
             counter: 0,
             peer_updates: HashMap::new(),
+            worker_without_model: vec![],
+            receive_from: HashMap::new(),
         }
     }
 
@@ -94,6 +98,26 @@ impl TrainingState {
 
     fn get_peer_updates(&self, peer_id: &PeerId) -> u32 {
         *self.peer_updates.get(peer_id).unwrap_or(&0u32)
+    }
+
+    fn pop_worker_without_model(&mut self) -> Option<PeerId> {
+        self.worker_without_model.pop()
+    }
+
+    fn push_worker_without_model(&mut self, peer_id: PeerId) {
+        self.worker_without_model.push(peer_id);
+    }
+
+    fn remove_receive_from(&mut self, peer_id: &PeerId) -> Option<PeerId> {
+        self.receive_from.remove(peer_id)
+    }
+
+    fn insert_receive_from(&mut self, source: PeerId, destination: PeerId) {
+        self.receive_from.insert(destination, source);
+    }
+
+    fn get_waiting_workers(&self) -> &[PeerId] {
+        &self.worker_without_model[..]
     }
 }
 
@@ -148,6 +172,52 @@ where
 
     let next_action = match status {
         ExecutorStatus::Train(train) => match train {
+            TrainStatus::Joined => {
+                let state = round_state.lock().await;
+                if state.round == 0 {
+                    ExecutorAction::Train(TrainAction::Idle {
+                        timeout: now + Duration::from_millis(100),
+                    })
+                } else {
+                    training_state
+                        .lock()
+                        .await
+                        .push_worker_without_model(peer_id);
+                    ExecutorAction::Train(TrainAction::WaitForModel {
+                        timeout: now + Duration::from_secs(1),
+                    })
+                }
+            }
+            TrainStatus::WaitedForModel => {
+                if let Some(sending_peer) =
+                    training_state.lock().await.remove_receive_from(&peer_id)
+                {
+                    ExecutorAction::Train(TrainAction::ReceiveModel {
+                        source: Reference::Peers {
+                            peers: vec![sending_peer],
+                            strategy: SelectionStrategy::All,
+                            resource: None,
+                        },
+                        timeout: now + Duration::from_secs(60),
+                    })
+                } else {
+                    ExecutorAction::Train(TrainAction::WaitForModel {
+                        timeout: now + Duration::from_secs(1),
+                    })
+                }
+            }
+            TrainStatus::ReceivedModel => {
+                // Lazy transition to other state
+                ExecutorAction::Train(TrainAction::Idle {
+                    timeout: now + Duration::from_secs(1),
+                })
+            }
+            TrainStatus::SentModel => {
+                // Lazy transition to other state
+                ExecutorAction::Train(TrainAction::Idle {
+                    timeout: now + Duration::from_secs(1),
+                })
+            }
             TrainStatus::Idle => {
                 let mut state = round_state.lock().await;
                 if !state.training_complete {
@@ -405,7 +475,20 @@ where
                         timeout: now + Duration::from_secs(1),
                     })
                 } else {
-                    ExecutorAction::Train(TrainAction::ExecuteBatch)
+                    let mut training = training_state.lock().await;
+                    if let Some(update_worker) = training.pop_worker_without_model() {
+                        training.insert_receive_from(peer_id, update_worker);
+                        ExecutorAction::Train(TrainAction::SendModel {
+                            target: Reference::Peers {
+                                peers: vec![update_worker],
+                                strategy: SelectionStrategy::One,
+                                resource: None,
+                            },
+                            timeout: now + Duration::from_secs(30),
+                        })
+                    } else {
+                        ExecutorAction::Train(TrainAction::ExecuteBatch)
+                    }
                 }
             }
             TrainStatus::PushedToHub => {
@@ -457,11 +540,16 @@ where
                         timeout: now + Duration::from_secs(5),
                     })
                 } else {
-                    let workers: Vec<_> = worker_pool
-                        .statistics()
-                        .into_iter()
-                        .map(|w| w.peer_id)
-                        .collect();
+                    let workers: Vec<_> = {
+                        let training = training_state.lock().await;
+                        let non_participating_worker = training.get_waiting_workers();
+                        worker_pool
+                            .statistics()
+                            .into_iter()
+                            .map(|w| w.peer_id)
+                            .filter(|w| !non_participating_worker.contains(w))
+                            .collect()
+                    };
 
                     if workers.is_empty() {
                         ExecutorAction::Aggregate(AggregateAction::Idle {

--- a/crates/worker/src/executor/bridge.rs
+++ b/crates/worker/src/executor/bridge.rs
@@ -49,6 +49,8 @@ use crate::{
     network::Network,
 };
 
+const FETCH_DIR: &str = "artifacts";
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Network error: {0}")]
@@ -280,14 +282,13 @@ async fn fetch_resource(
             let out = Retry::spawn(retry_strategy, || {
                 let data_providers = data_providers.clone();
                 let state = state.clone();
-                let dir_rel = "artifacts".to_string();
                 let mut out: Vec<FileResponse> = Vec::new();
                 async move {
-                    let dir_abs = safe_join(&state.work_dir, &dir_rel)?;
+                    let dir_abs = safe_join(&state.work_dir, FETCH_DIR)?;
                     fs::create_dir_all(&dir_abs).await?;
 
                     let file_name = hash;
-                    let rel = format!("{}/{}", dir_rel, file_name);
+                    let rel = format!("{}/{}", FETCH_DIR, file_name);
                     let abs = safe_join(&state.work_dir, &rel)?;
 
                     match fs::try_exists(&abs).await {
@@ -363,16 +364,15 @@ async fn fetch_resource(
             let out = Retry::spawn(retry_strategy, || {
                 let state = state.clone();
                 let resource = resource.clone();
-                let dir_rel = "artifacts".to_string();
                 let mut out: Vec<FileResponse> = Vec::new();
                 async move {
-                    let dir_abs = safe_join(&state.work_dir, &dir_rel)?;
+                    let dir_abs = safe_join(&state.work_dir, FETCH_DIR)?;
                     fs::create_dir_all(&dir_abs).await?;
                     let mut items = state.connector.fetch(resource).await?;
                     let mut idx: usize = 0;
                     while let Some(item) = items.next().await.transpose().map_err(Error::Io)? {
                         let (file_name, mut reader) = derive_name_and_reader(item, idx);
-                        let rel = format!("{}/{}", dir_rel, file_name);
+                        let rel = format!("{}/{}", &FETCH_DIR, file_name);
                         let abs = safe_join(&state.work_dir, &rel)?;
                         if let Some(parent) = abs.parent() {
                             fs::create_dir_all(parent).await?;
@@ -401,6 +401,7 @@ async fn fetch_resource(
 struct SendRequest {
     resource: Send,
     path: String,
+    remove_file: bool,
 }
 
 async fn send_resource(
@@ -441,7 +442,9 @@ async fn send_resource(
                         }
 
                         // We no longer need the file once it has been sent, so remove it.
-                        fs::remove_file(&file_path).await?;
+                        if req.remove_file{
+                            fs::remove_file(&file_path).await?;
+                        }
                         break;
                     };
                     let item = item_result?;

--- a/executors/accelerate/src/hypha/accelerate_executor/api.py
+++ b/executors/accelerate/src/hypha/accelerate_executor/api.py
@@ -28,9 +28,9 @@ class Session(AbstractContextManager["Session", None]):
     ) -> None:
         self._client.close()
 
-    def send_resource(self, resource: Any, path: str, timeout: float | None = None) -> None:
+    def send_resource(self, resource: Any, path: str, remove_file: bool = True, timeout: float | None = None) -> None:
         timeout_ms = int(timeout * 1000) if timeout is not None else None
-        req = {"resource": resource, "path": path, "timeout_ms": timeout_ms}
+        req = {"resource": resource, "path": path, "timeout_ms": timeout_ms, "remove_file": remove_file}
         # We must allow the client to wait at least as long as the requested timeout.
         # If timeout is None, wait forever.
         _ = self._client.post("http://hypha/resources/send", json=req, timeout=timeout).raise_for_status()

--- a/executors/accelerate/src/hypha/accelerate_executor/training.py
+++ b/executors/accelerate/src/hypha/accelerate_executor/training.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import shutil
 import time
 import uuid
 
@@ -9,7 +10,7 @@ import openlit  # type: ignore[import-untyped]
 import torch
 import torch.utils.data
 from accelerate import Accelerator
-from safetensors.torch import save_file, save_model
+from safetensors.torch import load_file, save_file, save_model
 
 from .api import Session
 from .dataset import IterableStreamDataSet
@@ -25,6 +26,7 @@ from .utils import (
 )
 
 FETCH_PATH = "artifacts"
+CURRENT_MODEL_NAME = "global_weights.pt"
 MIN_LOOP_TIME_MS = 100
 
 # NOTE: Enable system and GPU metrics collection on supported platforms.
@@ -86,7 +88,8 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
         training_data_iter = iter(training_dataloader)
 
         # Serialize the model to disk
-        previous_model_path = os.path.join(work_dir, "global_weights.pt")
+        previous_model_path = os.path.join(work_dir, CURRENT_MODEL_NAME)
+        # model = accelerator.unwrap_model(model)
         save_model(model, previous_model_path)
 
         epoch_counter = 1
@@ -97,7 +100,7 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
 
         current_status = {
             "executor": "train",
-            "details": {"state": "idle"},
+            "details": {"state": "joined"},
         }
 
         while True:
@@ -296,6 +299,110 @@ def main(socket_path: str, work_dir: str, job_json: str) -> None:  # noqa: PLR09
                         }
                         continue
                 current_status = {"executor": "train", "details": {"state": "pushed-to-hub"}}
+            elif kind == "send-model":
+                target = action.get("target")
+                if target is None:
+                    current_status = {
+                        "executor": "train",
+                        "details": {
+                            "state": "error",
+                            "type": "other",
+                            "message": "SendModel missing target reference",
+                        },
+                    }
+                    continue
+
+                timeout_ms = system_time_to_epoch_ms(action.get("timeout"))
+                timeout_sec = (timeout_ms - int(time.time() * 1000.0)) / 1000.0 if timeout_ms else None
+                if timeout_sec is not None and timeout_sec < 1.0:
+                    timeout_sec = 1.0
+
+                try:
+                    session.send_resource(target, CURRENT_MODEL_NAME, remove_file=False, timeout=timeout_sec)
+                    current_status = {
+                        "executor": "train",
+                        "details": {"state": "sent-model"},
+                    }
+                except Exception as exc:  # noqa: BLE001
+                    current_status = {
+                        "executor": "train",
+                        "details": {
+                            "state": "error",
+                            "type": "connection",
+                            "message": str(exc),
+                        },
+                    }
+
+            elif kind == "receive-model":
+                source = action.get("source")
+                if source is None:
+                    current_status = {
+                        "executor": "train",
+                        "details": {
+                            "state": "error",
+                            "type": "other",
+                            "message": "ReceiveModel missing source reference",
+                        },
+                    }
+                    continue
+
+                timeout_ms = system_time_to_epoch_ms(action.get("timeout"))
+                read_timeout = (timeout_ms - int(time.time() * 1000.0)) / 1000.0 if timeout_ms else None
+                if read_timeout is not None and read_timeout <= 0:
+                    # Scheduler will tell us what to do next.
+                    current_status = {
+                        "executor": "train",
+                        "details": {
+                            "state": "error",
+                            "type": "connection",
+                            "message": "ReceiveModel timeout reached before receive",
+                        },
+                    }
+                    continue
+                try:
+                    receive_path = f"incoming-{uuid.uuid4()}"
+                    with session.receive(source, receive_path, timeout=read_timeout) as receiver:
+                        updates_iter = iter(receiver)
+                        pointers = next(updates_iter)
+                        if pointers:
+                            incomming = pointers[-1] if isinstance(pointers, list) else pointers
+                            rel_path = incomming.get("path")
+                            if isinstance(rel_path, str):
+                                path = os.path.join(work_dir, rel_path)
+                                model.load_state_dict(load_file(path))
+                                os.remove(previous_model_path)
+                                shutil.copy(path, previous_model_path)
+                                os.remove(path)
+                except StopIteration:
+                    current_status = {
+                        "executor": "train",
+                        "details": {
+                            "state": "error",
+                            "type": "connection",
+                            "message": "Receiver stream closed; no updates to merge.",
+                        },
+                    }
+                    continue
+                except Exception as exc:  # noqa: BLE001
+                    current_status = {
+                        "executor": "train",
+                        "details": {
+                            "state": "error",
+                            "type": "connection",
+                            "message": str(exc),
+                        },
+                    }
+                    continue
+
+                current_status = {
+                    "executor": "train",
+                    "details": {"state": "applied-update"},
+                }
+            elif kind == "wait-for-model":
+                timeout_ms = system_time_to_epoch_ms(action.get("timeout"))
+                if timeout_ms is not None:
+                    sleep_until_epoch_ms(timeout_ms)
+                current_status = {"executor": "train", "details": {"state": "waited-for-model"}}
             else:
                 raise RuntimeError(f"Unhandled action kind: {kind}")
 


### PR DESCRIPTION
With the PR a new worker can join an ongoing training. If the worker joins during the training after the next model update, the first worker that reports `AppliedUpdate` will send the current model to the new worker. Bother worker will transition through `Idle` into the training.