### PR TITLE
Fix push streaming retry

### DIFF
--- a/crates/worker/src/connector/mod.rs
+++ b/crates/worker/src/connector/mod.rs
@@ -353,7 +353,7 @@ where
                                 let network = network.clone();
                                 async move {
                                     let retry_strategy =
-                                        FixedInterval::from_millis(200).map(jitter).take(6);
+                                        FixedInterval::from_millis(200).map(jitter).take(15);
 
                                     async fn attempt_push<T>(
                                         network: T,

--- a/crates/worker/src/executor/parameter_server.rs
+++ b/crates/worker/src/executor/parameter_server.rs
@@ -340,18 +340,12 @@ impl JobExecutor for ParameterServerExecutor {
                                     }
                                 };
 
-                                match Retry::spawn(retry_strategy.clone(), || {
-                                    let connector = connector.clone();
-                                    let send = send.clone();
-                                    let cancel = cancel.clone();
-                                    async move { broadcast_update(
+                                match broadcast_update(
                                     connector.clone(),
                                     send,
                                     gradient_file,
-                                    cancel.clone(),
+                                    cancel.clone()
                                 ).await
-                                    }
-                                }).await
                                 {
                                     Ok(()) => {
                                         pending_update = None;


### PR DESCRIPTION
Retrying a broadcast can result in sending multiple broadcast messages
to a worker because we don't differntiate between succesful sends and
not. We shouldn't do a retry here. Instead the retries on getting a
connection to a worker have been increased. In the future, we should
handle the retry from the scheduler.